### PR TITLE
Fixed the bugs:

### DIFF
--- a/main/plugins/org.talend.repository.hadoopcluster/src/org/talend/repository/hadoopcluster/service/HadoopClusterService.java
+++ b/main/plugins/org.talend.repository.hadoopcluster/src/org/talend/repository/hadoopcluster/service/HadoopClusterService.java
@@ -276,6 +276,10 @@ public class HadoopClusterService implements IHadoopClusterService {
         return true;
     }
 
+    public Connection getHadoopClusterConnectionBySubConnection(Connection hadoopSubConnection) {
+        return HCRepositoryUtil.getRelativeHadoopClusterConnection(hadoopSubConnection);
+    }
+
     @Override
     public String getHadoopClusterProperties(Connection hadoopSubConnection) {
         HadoopClusterConnection hadoopClusterConnection = HCRepositoryUtil


### PR DESCRIPTION
TBD-3202: [6.1.1] Hive properties dont get submitted correctly when
re-using context
TBD-3212: hadoop cluster:hadoop property is added double quotes when
drag hdfs schema to a standard job