### PR TITLE
TBD-3338: change back like before to enable add null for conditions

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/model/DistributionBean.java
+++ b/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/model/DistributionBean.java
@@ -153,9 +153,15 @@ public class DistributionBean implements IHDistribution {
     private Set<ComponentCondition> conditions = new HashSet<ComponentCondition>();
 
     public void addCondition(ComponentCondition c) {
-        if (c != null) {
-            conditions.add(c);
-        }
+        /*
+         * TBD-3338, do it like before,add condition always, even it's null. Because when build condition, will ignore
+         * all with the null
+         * 
+         * @see the method getDisplayShowIf with api ComponentConditionUtil.buildDistributionShowIf
+         */
+        // if (c != null) {
+        conditions.add(c);
+        // }
     }
 
     public ComponentCondition[] getConditions() {


### PR DESCRIPTION
Don't know it is ok for my fix (so simply like this)
Because related to CDH510MR2Distribution, will get the showif  value "(((false)))" and caused the problem.
https://github.com/Talend/tbd-studio-se/blob/bugfix/6.2/TBD-3338/main/plugins/org.talend.hadoop.distribution.cdh510mr2/src/main/java/org/talend/hadoop/distribution/cdh510mr2/CDH510MR2Distribution.java#L61

but for others are null, and will add null always. 
https://github.com/Talend/tdi-studio-se/blob/b5bca732a4a20862a3fc023cbe84b08d2f11a7a7/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/model/components/EmfComponent.java#L1631

