### PR TITLE
fix(TBD-4803): correct hive-exec dependency declaration for Dataproc 1.1

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.dataproc11/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.dataproc11/plugin.xml
@@ -412,7 +412,7 @@
 		<!-- hive on spark -->
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
-            id="hive-exec-dataproc1.1"
+            id="hive-exec-dataproc11"
             name="hive-exec-2.1.0-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/hive-exec-2.1.0-dataproc11/6.0.0">
         </libraryNeeded>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

The `hive-exec` dependency is wrongly declared for Dataproc 1.1 distribution, causing all Spark jobs including a Hive component to fail.

**What is the new behavior?**

The `hive-exec` dependency is now correctly declared.
