### PR TITLE
TUP-17227: WHen reuse context group for hadoop cluster,miss hadoop properties parameter

### DIFF
--- a/main/plugins/org.talend.repository.hadoopcluster/src/org/talend/repository/hadoopcluster/ui/context/handler/HadoopClusterContextHandler.java
+++ b/main/plugins/org.talend.repository.hadoopcluster/src/org/talend/repository/hadoopcluster/ui/context/handler/HadoopClusterContextHandler.java
@@ -531,7 +531,8 @@ public class HadoopClusterContextHandler extends AbstractRepositoryContextHandle
         if (conn instanceof HadoopClusterConnection) {
             HadoopClusterConnection hadoopConn = (HadoopClusterConnection) conn;
             conVarList = getConAdditionProperties(HadoopRepositoryUtil.getHadoopPropertiesList(hadoopConn.getHadoopProperties()));
-            conVarList = getConAdditionProperties(HadoopRepositoryUtil.getHadoopPropertiesList(hadoopConn.getSparkProperties()));
+            conVarList.addAll(
+                    getConAdditionProperties(HadoopRepositoryUtil.getHadoopPropertiesList(hadoopConn.getSparkProperties())));
         }
         return conVarList;
     }

--- a/test/plugins/org.talend.repository.hadoopcluster.test/src/main/java/org/talend/repository/hadoopcluster/ui/context/handler/HadoopClusterContextHandlerTest.java
+++ b/test/plugins/org.talend.repository.hadoopcluster.test/src/main/java/org/talend/repository/hadoopcluster/ui/context/handler/HadoopClusterContextHandlerTest.java
@@ -1,0 +1,52 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.repository.hadoopcluster.ui.context.handler;
+
+import static org.junit.Assert.*;
+
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.talend.repository.hadoopcluster.util.ClusterTestUtil;
+import org.talend.repository.model.hadoopcluster.HadoopClusterConnection;
+import org.talend.repository.model.hadoopcluster.HadoopClusterConnectionItem;
+
+/**
+ * created by ycbai on 2017年4月10日 Detailled comment
+ *
+ */
+public class HadoopClusterContextHandlerTest {
+
+    private HadoopClusterContextHandler contextHandler;
+
+    @Before
+    public void before() {
+        contextHandler = new HadoopClusterContextHandler();
+    }
+
+    @Test
+    public void testGetConAdditionPropertiesForContextMode() {
+        String hadoopPropertiesJsonStr = "[{\"PROPERTY\":\"hadoopProp\",\"VALUE\":\"hadoopPropValue\"}]"; //$NON-NLS-1$
+        String sparkPropertiesJsonStr = "[{\"PROPERTY\":\"sparkProp\",\"VALUE\":\"sparkPropValue\"}]"; //$NON-NLS-1$
+        HadoopClusterConnectionItem hadoopClusterItem = ClusterTestUtil.createDefaultHadoopClusterItem();
+        HadoopClusterConnection hadoopClusterConn = (HadoopClusterConnection) hadoopClusterItem.getConnection();
+        hadoopClusterConn.setHadoopProperties(hadoopPropertiesJsonStr);
+        hadoopClusterConn.setSparkProperties(sparkPropertiesJsonStr);
+
+        Set<String> additionProperties = contextHandler.getConAdditionPropertiesForContextMode(hadoopClusterConn);
+        assertTrue(additionProperties.contains("hadoopProp")); //$NON-NLS-1$
+        assertTrue(additionProperties.contains("sparkProp")); //$NON-NLS-1$
+    }
+
+}


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [x] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
