### PR TITLE
fix(TBD-4805): add double quotes for each column's comment

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tHiveCreateTable/hiveUtil.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tHiveCreateTable/hiveUtil.javajet
@@ -28,7 +28,7 @@
 	        	String comment = metadataColumn.getComment();
 	        	if(comment!=null && !"".equals(comment) && !"\"\"".equals(comment)) {
 %>
-					String comment_<%=index%>_<%=count%>_<%=cid%> = <%=comment%>;
+					String comment_<%=index%>_<%=count%>_<%=cid%> = "<%=comment%>";
 <%
 	        		createTableSQL.append(" COMMENT '");
 		    		createTableSQL.append("\" + ");
@@ -96,7 +96,7 @@
         		if(comment!=null && !"".equals(comment) && !"\"\"".equals(comment)) {
         			schemaBuilder.append(", ");
 %>
-					String comment_<%=index%>_<%=count%>_<%=cid%> = <%=comment%>;
+					String comment_<%=index%>_<%=count%>_<%=cid%> = "<%=comment%>";
 <%
 	        		schemaBuilder.append(quote).append("doc").append(quote);
 	        		schemaBuilder.append(" : ");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

There's no double quote on column's comment.  As a result, there'll be a compile error.

**What is the new behavior?**

Add double quotes for each column's comment, then the compile errors disappear.

**Other information**:
