### PR TITLE
fix TUP-17486:The hive-metastore-1.2.1.2.3.2.0-2950.jar will be renamed during build job.

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tPigStoreResult/tPigStoreResult_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tPigStoreResult/tPigStoreResult_java.xml
@@ -377,7 +377,7 @@
 				MVN="mvn:org.talend.libraries/hive-exec-1.2.1.2.3.2.0-2950/6.1.0"
 				REQUIRED_IF="(STORE=='HCATSTORER') AND (HBASE_VERSION=='HDP_2_3') AND (DISTRIBUTION!='CUSTOM')" />
 			<IMPORT NAME="hive-metastore-1.2.1.2.3.2.0-2950.jar" MODULE="hive-metastore-1.2.1.2.3.2.0-2950.jar"
-				MVN="mvn:org.talend.libraries/-1.2.1.2.3.2.0-2950/6.1.0"
+				MVN="mvn:org.talend.libraries/hive-metastore-1.2.1.2.3.2.0-2950/6.1.0"
 				REQUIRED_IF="(STORE=='HCATSTORER') AND (HBASE_VERSION=='HDP_2_3') AND (DISTRIBUTION!='CUSTOM')" />
 			<IMPORT NAME="jdo-api-3.0.1.jar" MODULE="jdo-api-3.0.1.jar"
 				MVN="mvn:org.talend.libraries/jdo-api-3.0.1/6.0.0"


### PR DESCRIPTION
during build job.

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
The hive-metastore-1.2.1.2.3.2.0-2950.jar will be renamed during build job.Intercept

**What is the new behavior?**
cased by the intercept jar name in the tPigStoreResult xml 
