### PR TITLE
fix(TBD-4841): remove inconsistencies on Dataproc 1.1 Spark dependenc…

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.dataproc11/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.dataproc11/plugin.xml
@@ -188,8 +188,8 @@
          <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="kafka-clients-dataproc11"
-            name="kafka-clients-0.10.2.0.jar"
-            mvn_uri="mvn:org.talend.libraries/kafka-clients-0.10.2.0/6.3.0">
+            name="kafka-clients-0.10.0.1.jar"
+            mvn_uri="mvn:org.talend.libraries/kafka-clients-0.10.0.1/6.3.0">
         </libraryNeeded>
             
         <!-- SPARK libraries --> 

--- a/main/plugins/org.talend.hadoop.distribution.dataproc11/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.dataproc11/plugin.xml
@@ -188,8 +188,8 @@
          <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="kafka-clients-dataproc11"
-            name="kafka-clients-0.10.0.1.jar"
-            mvn_uri="mvn:org.talend.libraries/kafka-clients-0.10.0.1/6.3.0">
+            name="kafka-clients-0.10.2.0.jar"
+            mvn_uri="mvn:org.talend.libraries/kafka-clients-0.10.2.0/6.3.0">
         </libraryNeeded>
             
         <!-- SPARK libraries --> 
@@ -211,98 +211,98 @@
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-graphx-dataproc11"
-            name="spark-graphx_2.11-2.0.2.jar"
+            name="spark-graphx_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-graphx_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-hive-dataproc11"
-            name="spark-hive_2.11-2.0.2.jar"
+            name="spark-hive_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-hive_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-launcher-dataproc11"
-            name="spark-launcher_2.11-2.0.2.jar"
+            name="spark-launcher_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-launcher_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-mllib-dataproc11"
-            name="spark-mllib_2.11-2.0.2.jar"
+            name="spark-mllib_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-mllib_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-mllib-local-dataproc11"
-            name="spark-mllib-local_2.11-2.0.2.jar"
+            name="spark-mllib-local_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-mllib-local_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-network-common-dataproc11"
-            name="spark-network-common_2.11-2.0.2.jar"
+            name="spark-network-common_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-network-common_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-network-shuffle-dataproc11"
-            name="spark-network-shuffle_2.11-2.0.2.jar"
+            name="spark-network-shuffle_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-network-shuffle_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-repl-dataproc11"
-            name="spark-repl_2.11-2.0.2.jar"
+            name="spark-repl_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-repl_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-sketch-dataproc11"
-            name="spark-sketch_2.11-2.0.2.jar"
+            name="spark-sketch_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-sketch_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-sql-dataproc11"
-            name="spark-sql_2.11-2.0.2.jar"
+            name="spark-sql_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-sql_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-streaming-dataproc11"
-            name="spark-streaming_2.11-2.0.2.jar"
+            name="spark-streaming_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-streaming_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-tags-dataproc11"
-            name="spark-tags_2.11-2.0.2.jar"
+            name="spark-tags_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-tags_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-unsafe-dataproc11"
-            name="spark-unsafe_2.11-2.0.2.jar"
+            name="spark-unsafe_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-unsafe_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc11"
             id="spark-yarn-dataproc11"
-            name="spark-yarn_2.11-2.0.2.jar"
+            name="spark-yarn_2.11-2.0.2-dataproc11.jar"
             mvn_uri="mvn:org.talend.libraries/spark-yarn_2.11-2.0.2-dataproc11/6.0.0">
         </libraryNeeded>
         


### PR DESCRIPTION
…ies names

**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

See https://jira.talendforge.org/browse/TBD-4841.

The classpath generated within the job run script was wrong for Dataproc 1.1 : for example the missing class mentioned in the above JIRA is supposed to come from `spark-network-common_2.11-2.0.2-dataproc11.jar` while the script was mistakenly looking for `spark-network-common_2.11-2.0.2.jar`.

This was caused by name inconsistencies within the spark dependencies declared in the Dataproc 1.1 `plugin.xml`. 

**What is the new behavior?**

All spark dependencies are now suffixed with `-dataproc11` as expected.
