### PR TITLE
feat TUP-17522:Add a button on Google Cloud Dataproc wizard to browse Google credentials file

### DIFF
--- a/main/plugins/org.talend.repository.hadoopcluster/src/org/talend/repository/hadoopcluster/ui/GoogleDataprocInfoForm.java
+++ b/main/plugins/org.talend.repository.hadoopcluster/src/org/talend/repository/hadoopcluster/ui/GoogleDataprocInfoForm.java
@@ -29,6 +29,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.talend.commons.ui.swt.formtools.Form;
+import org.talend.commons.ui.swt.formtools.LabelledFileField;
 import org.talend.commons.ui.swt.formtools.LabelledText;
 import org.talend.commons.ui.swt.formtools.UtilsButton;
 import org.talend.core.database.conn.ConnParameterKeys;
@@ -70,7 +71,7 @@ public class GoogleDataprocInfoForm extends AbstractHadoopForm<HadoopClusterConn
 
     private Composite credentialsComposite;
 
-    private LabelledText pathToCredentialsNameText;
+    private LabelledFileField pathToCredentialsNameText;
 
     protected Composite propertiesComposite;
 
@@ -146,13 +147,14 @@ public class GoogleDataprocInfoForm extends AbstractHadoopForm<HadoopClusterConn
         credentialsBtn.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false, 4, 1));
 
         credentialsComposite = new Composite(authPartComposite, SWT.NULL);
-        GridLayout credentialsLayout = new GridLayout(2, false);
+        GridLayout credentialsLayout = new GridLayout(3, false);
         credentialsLayout.marginWidth = 0;
         credentialsLayout.marginHeight = 0;
         credentialsComposite.setLayout(credentialsLayout);
         credentialsComposite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-        pathToCredentialsNameText = new LabelledText(credentialsComposite,
-                Messages.getString("GoogleDataprocInfoForm.text.authentication.credentials"), 1); //$NON-NLS-1$
+        String[] extensions = { "*.*" }; //$NON-NLS-1$
+        pathToCredentialsNameText = new LabelledFileField(credentialsComposite,
+                Messages.getString("GoogleDataprocInfoForm.text.authentication.credentials"), extensions); //$NON-NLS-1$
     }
 
     protected void addSparkPropertiesFields() {


### PR DESCRIPTION
credentials file.

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
=>Not have the file select browse button for Path to Google Credentials file


**What is the new behavior?**
=>Add a button on Google Cloud Dataproc wizard to browse Google credentials file