### PR TITLE
fix(TUP-17567): there should no "Create Oozie" context menu on Google Hadoop Cluster

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.dataproc11/src/main/java/org/talend/hadoop/distribution/dataproc11/Dataproc11Distribution.java
+++ b/main/plugins/org.talend.hadoop.distribution.dataproc11/src/main/java/org/talend/hadoop/distribution/dataproc11/Dataproc11Distribution.java
@@ -240,4 +240,9 @@ public class Dataproc11Distribution extends AbstractDistribution implements HDFS
     public SparkStreamingKafkaVersion getSparkStreamingKafkaVersion(ESparkVersion sparkVersion) {
         return SparkStreamingKafkaVersion.KAFKA_0_10;
     }
+
+    @Override
+    public boolean doSupportOozie() {
+        return false;
+    }
 }

--- a/test/plugins/org.talend.hadoop.distribution.dataproc11.test/src/org/talend/hadoop/distribution/dataproc11/test/Dataproc11DistributionTest.java
+++ b/test/plugins/org.talend.hadoop.distribution.dataproc11.test/src/org/talend/hadoop/distribution/dataproc11/test/Dataproc11DistributionTest.java
@@ -49,5 +49,6 @@ public class Dataproc11DistributionTest {
         assertFalse(((SparkStreamingComponent) distribution).doSupportSparkStandaloneMode());
         assertTrue(((SparkStreamingComponent) distribution).doSupportSparkYarnClientMode());
         assertTrue(((SparkStreamingComponent) distribution).doSupportBackpressure());
+        assertFalse(distribution.doSupportOozie());
     }
 }


### PR DESCRIPTION
fix(TUP-17567): there should no "Create Oozie" context menu on Google Hadoop Cluster

https://jira.talendforge.org/browse/TUP-17567

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
