### PR TITLE
feat(TBD-4866): fix CDH 5.8 Spark 2.0 integration regarding Kafka and update distribution API

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.cdh580spark2/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.cdh580spark2/plugin.xml
@@ -172,9 +172,9 @@
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="json4s-jackson_2.11-3.2.11.jar" name="json4s-jackson_2.11-3.2.11.jar" mvn_uri="mvn:org.talend.libraries/json4s-jackson_2.11-3.2.11/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="jta-1.1.jar" name="jta-1.1.jar" mvn_uri="mvn:org.talend.libraries/jta-1.1/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="jtransforms-2.4.0.jar" name="jtransforms-2.4.0.jar" mvn_uri="mvn:org.talend.libraries/jtransforms-2.4.0/6.0.0"/>
-        <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="jul-to-slf4j-1.7.16.jar" name="jul-to-slf4j-1.7.16.jar" mvn_uri="mvn:org.talend.libraries/jul-to-slf4j-1.7.16/6.0.0"/>
-        <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="kafka_2.11-0.9.0-kafka-2.0.0.jar" name="kafka_2.11-0.9.0-kafka-2.0.0.jar" mvn_uri="mvn:org.talend.libraries/kafka_2.11-0.9.0-kafka-2.0.0/6.0.0"/>
-        <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="kafka-clients-0.9.0-kafka-2.0.0.jar" name="kafka-clients-0.9.0-kafka-2.0.0.jar" mvn_uri="mvn:org.talend.libraries/kafka-clients-0.9.0-kafka-2.0.0/6.0.0"/>
+        <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="jul-to-slf4j-1.7.16.jar" name="jul-to-slf4j-1.7.16.jar" mvn_uri="mvn:org.talend.libraries/jul-to-slf4j-1.7.16/6.0.0"/>        
+        <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="kafka_2.11-0.10.0-kafka-2.1.0.jar" name="kafka_2.11-0.10.0-kafka-2.1.0.jar" mvn_uri="mvn:org.talend.libraries/kafka_2.11-0.10.0-kafka-2.1.0/6.0.0"/>
+        <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="kafka-clients-0.10.0-kafka-2.1.0.jar" name="kafka-clients-0.10.0-kafka-2.1.0.jar" mvn_uri="mvn:org.talend.libraries/kafka-clients-0.10.0-kafka-2.1.0/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="kryo-shaded-3.0.3.jar" name="kryo-shaded-3.0.3.jar" mvn_uri="mvn:org.talend.libraries/kryo-shaded-3.0.3/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="libfb303-0.9.2.jar" name="libfb303-0.9.2.jar" mvn_uri="mvn:org.talend.libraries/libfb303-0.9.2/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="libthrift-0.9.2.jar" name="libthrift-0.9.2.jar" mvn_uri="mvn:org.talend.libraries/libthrift-0.9.2/6.0.0"/>
@@ -231,7 +231,7 @@
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="spark-streaming_2.11-2.0.0.cloudera1.jar" name="spark-streaming_2.11-2.0.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-streaming_2.11-2.0.0.cloudera1/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="spark-streaming-flume_2.11-2.0.0.cloudera1.jar" name="spark-streaming-flume_2.11-2.0.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-streaming-flume_2.11-2.0.0.cloudera1/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="spark-streaming-flume-sink_2.11-2.0.0.cloudera1.jar" name="spark-streaming-flume-sink_2.11-2.0.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-streaming-flume-sink_2.11-2.0.0.cloudera1/6.0.0"/>
-        <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="spark-streaming-kafka-0-8_2.11-2.0.0.cloudera1.jar" name="spark-streaming-kafka-0-8_2.11-2.0.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-streaming-kafka-0-8_2.11-2.0.0.cloudera1/6.0.0"/>
+        <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="spark-streaming-kafka-0-10_2.11-2.0.0.cloudera1.jar" name="spark-streaming-kafka-0-10_2.11-2.0.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-streaming-kafka-0-10_2.11-2.0.0.cloudera1/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="spark-streaming-kinesis-asl-assembly_2.11-2.0.0.jar" name="spark-streaming-kinesis-asl-assembly_2.11-2.0.0.jar" mvn_uri="mvn:org.talend.libraries/spark-streaming-kinesis-asl-assembly_2.11-2.0.0/6.0.0"/>                
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="spark-tags_2.11-2.0.0.cloudera1.jar" name="spark-tags_2.11-2.0.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-tags_2.11-2.0.0.cloudera1/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh580spark2" id="spark-unsafe_2.11-2.0.0.cloudera1.jar" name="spark-unsafe_2.11-2.0.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-unsafe_2.11-2.0.0.cloudera1/6.0.0"/>
@@ -510,13 +510,6 @@
             id="automaton-1.11-8"
             name="automaton-1.11-8.jar"
             mvn_uri="mvn:org.talend.libraries/automaton-1.11-8/6.1.0">
-        </libraryNeeded>
-        
-        <libraryNeeded
-            context="plugin:org.talend.hadoop.distribution.cdh580spark2"
-            id="spark-streaming-kafka-cdh5.8.1"
-            name="spark-streaming-kafka_2.10-1.6.0-cdh5.8.1.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-streaming-kafka_2.10-1.6.0-cdh5.8.1/6.1.0">
         </libraryNeeded>
                 
         <libraryNeeded
@@ -873,10 +866,9 @@
                 description="Spark Kafka assembly libraries for CDH 5.8 that are MRREQUIRED"
                 id="SPARK-KAFKA-ASSEMBLY-LIB-MRREQUIRED-CDH580_SPARK2"
                 name="SPARK-KAFKA-ASSEMBLY-LIB-MRREQUIRED-CDH580_SPARK2">
-            <library id="spark-streaming-kafka-cdh5.8.1"/>
-            <library id="kafka_2.11-0.9.0-kafka-2.0.0.jar"/>
-            <library id="kafka-clients-0.9.0-kafka-2.0.0.jar"/>
-            <library id="spark-streaming-kafka-0-8_2.11-2.0.0.cloudera1.jar"/>
+            <library id="kafka_2.11-0.10.0-kafka-2.1.0.jar"/>
+            <library id="kafka-clients-0.10.0-kafka-2.1.0.jar"/>
+            <library id="spark-streaming-kafka-0-10_2.11-2.0.0.cloudera1.jar"/>
         </libraryNeededGroup>
         
         <!-- Spark Kafka Client group MRREQUIRED -->
@@ -884,11 +876,7 @@
                 description="Spark Kafka client libraries for CDH 5.8 that are MRREQUIRED"
                 id="SPARK-KAFKA-CLIENT-LIB-MRREQUIRED-CDH580_SPARK2"
                 name="SPARK-KAFKA-CLIENT-LIB-MRREQUIRED-CDH580_SPARK2">
-            <library id="spark-streaming-kafka-cdh5.8.1"/>
-            <library id="kafka_2.11-0.9.0-kafka-2.0.0.jar"/>
-            <library id="kafka-clients-0.9.0-kafka-2.0.0.jar"/>
-            <library id="spark-streaming-kafka-0-8_2.11-2.0.0.cloudera1.jar"/>
-            
+            <library id="kafka-clients-0.10.0-kafka-2.1.0.jar"/> 
         </libraryNeededGroup>
         
         <!-- Spark Kafka Avro group MRREQUIRED -->

--- a/main/plugins/org.talend.hadoop.distribution.cdh580spark2/src/main/java/org/talend/hadoop/distribution/cdh580spark2/CDH580Spark2Distribution.java
+++ b/main/plugins/org.talend.hadoop.distribution.cdh580spark2/src/main/java/org/talend/hadoop/distribution/cdh580spark2/CDH580Spark2Distribution.java
@@ -43,6 +43,7 @@ import org.talend.hadoop.distribution.condition.ComponentCondition;
 import org.talend.hadoop.distribution.constants.SparkBatchConstant;
 import org.talend.hadoop.distribution.constants.SparkStreamingConstant;
 import org.talend.hadoop.distribution.constants.cdh.IClouderaDistribution;
+import org.talend.hadoop.distribution.kafka.SparkStreamingKafkaVersion;
 import org.talend.hadoop.distribution.spark.SparkClassPathUtils;
 
 @SuppressWarnings("nls")
@@ -293,5 +294,10 @@ public class CDH580Spark2Distribution extends AbstractDistribution implements IC
     @Override
     public boolean doSupportOozie() {
         return false;
+    }
+
+    @Override
+    public SparkStreamingKafkaVersion getSparkStreamingKafkaVersion(ESparkVersion sparkVersion) {
+        return SparkStreamingKafkaVersion.KAFKA_0_10;
     }
 }

--- a/main/plugins/org.talend.hadoop.distribution.hdp250/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.hdp250/plugin.xml
@@ -328,13 +328,6 @@
             name="spark-streaming-kafka-assembly_2.10-1.6.2.2.5.0.0-1245.jar"
             mvn_uri="mvn:org.talend.libraries/spark-streaming-kafka-assembly_2.10-1.6.2.2.5.0.0-1245/6.3.0">
         </libraryNeeded>
-       
-        <libraryNeeded
-            context="plugin:org.talend.hadoop.distribution.hdp250"
-            id="kafka-HDP_2_5"
-            name="kafka_2.10-0.10.0.2.5.0.0-1245.jar"
-            mvn_uri="mvn:org.talend.libraries/kafka_2.10-0.10.0.2.5.0.0-1245/6.3.0">
-        </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.hdp250"
@@ -1042,7 +1035,6 @@
                 id="SPARK-KAFKA-ASSEMBLY-LIB-MRREQUIRED-HDP_2_5"
                 name="SPARK-KAFKA-ASSEMBLY-LIB-MRREQUIRED-HDP_2_5">
             <library id="spark-streaming-kafka-HDP_2_5"/>
-            <library id="kafka-HDP_2_5"/>
             <library id="metrics-core-2.2.0.jar"/>
         </libraryNeededGroup>
         

--- a/main/plugins/org.talend.hadoop.distribution.hdp250/src/org/talend/hadoop/distribution/hdp250/HDP250Distribution.java
+++ b/main/plugins/org.talend.hadoop.distribution.hdp250/src/org/talend/hadoop/distribution/hdp250/HDP250Distribution.java
@@ -413,4 +413,9 @@ public class HDP250Distribution extends AbstractDistribution implements HDFSComp
     public boolean isImpactedBySqoop2995() {
         return true;
     }
+
+    @Override
+    public boolean doSupportKerberizedKafka() {
+        return true;
+    }
 }

--- a/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/AbstractDistribution.java
+++ b/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/AbstractDistribution.java
@@ -230,6 +230,10 @@ public abstract class AbstractDistribution {
         return SparkStreamingKafkaVersion.KAFKA_0_8;
     }
 
+    public boolean doSupportKerberizedKafka() {
+        return false;
+    }
+
     public boolean doSupportHDFSEncryption() {
         return false;
     }
@@ -261,8 +265,8 @@ public abstract class AbstractDistribution {
     public boolean isGoogleDataprocDistribution() {
         return false;
     }
-    
+
     public boolean doSupportOozie() {
-    	return true;
+        return true;
     }
 }

--- a/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/component/SparkStreamingComponent.java
+++ b/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/component/SparkStreamingComponent.java
@@ -48,6 +48,8 @@ public interface SparkStreamingComponent extends SparkComponent {
      * This method defines whether the distribution provides a degraded Kerberos support with the spark-streaming-kafka
      * connector. "Degraded" because the spark-streaming-kafka connector does not provide any official Kerberos support
      * at the time of writing, but some vendors such as HDP provided workarounds.
+     *
+     * All Spark 2 distributions can support kerberized Kafka regardless of the return value of this method.
      * 
      * @return whether a workaround is available regarding the support of Kerberos using the spark-streaming-kafka
      * connector.

--- a/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/component/SparkStreamingComponent.java
+++ b/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/component/SparkStreamingComponent.java
@@ -37,10 +37,21 @@ public interface SparkStreamingComponent extends SparkComponent {
 
     /**
      * This method defines which version of the spark-streaming-kafka connector the distribution does support.
+     * 
      * @param sparkVersion version of spark used for streaming
      * 
      * @return the version of the spark-streaming-kafka connector.
      */
     public SparkStreamingKafkaVersion getSparkStreamingKafkaVersion(ESparkVersion sparkVersion);
+
+    /**
+     * This method defines whether the distribution provides a degraded Kerberos support with the spark-streaming-kafka
+     * connector. "Degraded" because the spark-streaming-kafka connector does not provide any official Kerberos support
+     * at the time of writing, but some vendors such as HDP provided workarounds.
+     * 
+     * @return whether a workaround is available regarding the support of Kerberos using the spark-streaming-kafka
+     * connector.
+     */
+    public boolean doSupportKerberizedKafka();
 
 }

--- a/test/plugins/org.talend.hadoop.distribution.cdh580spark2.test/src/org/talend/hadoop/distribution/cdh580spark2/test/CDH580Spark2DistributionTest.java
+++ b/test/plugins/org.talend.hadoop.distribution.cdh580spark2.test/src/org/talend/hadoop/distribution/cdh580spark2/test/CDH580Spark2DistributionTest.java
@@ -22,6 +22,7 @@ import org.talend.hadoop.distribution.component.HadoopComponent;
 import org.talend.hadoop.distribution.component.MRComponent;
 import org.talend.hadoop.distribution.component.SparkBatchComponent;
 import org.talend.hadoop.distribution.component.SparkStreamingComponent;
+import org.talend.hadoop.distribution.kafka.SparkStreamingKafkaVersion;
 
 /**
  * Test class for the {@link CDH580Spark2Distribution} distribution.
@@ -65,6 +66,8 @@ public class CDH580Spark2DistributionTest {
         assertTrue(((SparkStreamingComponent) distribution).doSupportSparkYarnClientMode());
         assertTrue(((SparkStreamingComponent) distribution).doSupportSparkYarnClientMode());
         assertTrue(((SparkStreamingComponent) distribution).doSupportBackpressure());
+        assertEquals(SparkStreamingKafkaVersion.KAFKA_0_10,
+                ((SparkStreamingComponent) distribution).getSparkStreamingKafkaVersion(ESparkVersion.SPARK_2_0));
 
         assertTrue(distribution.doSupportHDFSEncryption());
     }

--- a/test/plugins/org.talend.hadoop.distribution.hdp250.test/src/org/talend/hadoop/distribution/hdp250/test/HDP250DistributionTest.java
+++ b/test/plugins/org.talend.hadoop.distribution.hdp250.test/src/org/talend/hadoop/distribution/hdp250/test/HDP250DistributionTest.java
@@ -105,6 +105,7 @@ public class HDP250DistributionTest extends AbstractDistributionTest {
         assertFalse(((SparkStreamingComponent) distribution).doSupportSparkStandaloneMode());
         assertTrue(((SparkStreamingComponent) distribution).doSupportSparkYarnClientMode());
         assertTrue(((SparkStreamingComponent) distribution).doSupportBackpressure());
+        assertTrue(((SparkStreamingComponent) distribution).doSupportKerberizedKafka());
 
         assertTrue(distribution instanceof HCatalogComponent);
         assertFalse(distribution instanceof ImpalaComponent);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [X] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

- There is no support of kerberized Kafka in Spark Streaming for any distribution.
- CDH 5.8 Spark 2 was integrated with the wrong Kafka artifacts, preventing Kerberos and SSL to work.

**What is the new behavior?**

- The distribution API has been updated to handle kerberized Kafka for some Spark 1.6 distributions : only HDP has backported the new Kafka consumer API in their spark-streaming-kafka connector for Spark 1.6. This has been validated against HDP 2.5 (it might work also with HDP 2.4 but did not invest the time to investigate this at the time of writing).
- CDH 5.8 Spark 2 now integrates the right Kafka artifacts

**Other information**: 

This PR should only be merged alongside of https://github.com/Talend/tbd-studio-ee/pull/156