### PR TITLE
fix(TUP-17545):Hadoop properties filter is not token effect when hadoop

### DIFF
--- a/main/plugins/org.talend.repository.hadoopcluster/src/org/talend/repository/hadoopcluster/conf/RetrieveLocalConfsService.java
+++ b/main/plugins/org.talend.repository.hadoopcluster/src/org/talend/repository/hadoopcluster/conf/RetrieveLocalConfsService.java
@@ -179,7 +179,7 @@ public class RetrieveLocalConfsService implements IRetrieveConfsService {
         filterProps = filterProperties;
     }
 
-    private void applyFilterInConfFile(File confFile, List<String> filterProperties) {
+    public void applyFilterInConfFile(File confFile, List<String> filterProperties) {
         if (confFile == null || filterProperties == null || filterProperties.size() == 0) {
             return;
         }


### PR DESCRIPTION
cluster is created throuth retrieve from jobserver
https://jira.talendforge.org/browse/TUP-17545

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
