### PR TITLE
fix(TBD-5148): Add jackson-core-asl dependency in HDInsight 3.6 distribution

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.hdinsight360/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.hdinsight360/plugin.xml
@@ -85,6 +85,11 @@
         	name="guava-14.0.1.jar" 
         	mvn_uri="mvn:org.talend.libraries/guava-14.0.1/6.0.0">
         </libraryNeeded>
+        <libraryNeeded 
+        	context="plugin:org.talend.hadoop.distribution.hdinsight360" 
+        	id="jackson-core-asl-1.9.13" 
+        	name="jackson-core-asl-1.9.13.jar" 
+        	mvn_uri="mvn:org.talend.libraries/jackson-core-asl-1.9.13/6.0.0"/>
         
         <!-- Hive libraries -->  
         <libraryNeeded
@@ -184,7 +189,7 @@
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.hdinsight360" id="spark-network-common_2.11-2.1.0.2.6.0.2-76" name="spark-network-common_2.11-2.1.0.2.6.0.2-76.jar" mvn_uri="mvn:org.talend.libraries/spark-network-common_2.11-2.1.0.2.6.0.2-76/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.hdinsight360" id="spark-sql_2.11-2.1.0.2.6.0.2-76" name="spark-sql_2.11-2.1.0.2.6.0.2-76.jar" mvn_uri="mvn:org.talend.libraries/spark-sql_2.11-2.1.0.2.6.0.2-76/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.hdinsight360" id="spark-streaming_2.11-2.1.0.2.6.0.2-76" name="spark-streaming_2.11-2.1.0.2.6.0.2-76.jar" mvn_uri="mvn:org.talend.libraries/spark-streaming_2.11-2.1.0.2.6.0.2-76/6.0.0"/>
-
+        
         <!-- Big Data launcher libraries -->
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.hdinsight360"
@@ -370,6 +375,7 @@
             <library id="wsdl4j-1.6.3.jar" />
             <library id="azure-storage-5.0.0.jar" />
             <library id="jackson-core-2.8.4.jar" />
+        	<library id="jackson-core-asl-1.9.13" />
         </libraryNeededGroup>
         
     </extension>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

Compile error when using tAvroOutput in HDI 36 Spark job.

**What is the new behavior?**

No compile error when using tAvroOutput in HDI 36 Spark job.

**Other information**:
