### PR TITLE
fix(TBD-5149): Add commons-logging dependency to HDI_36_COMMON_LIBRARIES group

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.hdinsight360/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.hdinsight360/plugin.xml
@@ -376,6 +376,7 @@
             <library id="azure-storage-5.0.0.jar" />
             <library id="jackson-core-2.8.4.jar" />
         	<library id="jackson-core-asl-1.9.13" />
+        	<library id="commons-logging-1.1.3" />
         </libraryNeededGroup>
         
     </extension>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

Compile error when using tNormalize component in Spark job with HDI 36.

**What is the new behavior?**

Add commons-logging dependency to HDI_36_COMMON_LIBRARIES group. No compile error.

**Other information**:
