### PR TITLE
fix(TBD-4883): Add netty-all dependency on tHBaseConnection CDH580

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tHBaseConnection/tHBaseConnection_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tHBaseConnection/tHBaseConnection_java.xml
@@ -588,6 +588,10 @@
 				MVN="mvn:org.talend.libraries/netty-3.6.6.Final/6.0.0"
 				UrlPath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/netty-3.6.6.Final.jar"
 				REQUIRED_IF="HBASE_VERSION=='Cloudera_CDH5' AND (DISTRIBUTION!='CUSTOM')" />
+			<IMPORT NAME="netty-all-4.0.29.Final.jar" MODULE="netty-all-4.0.29.Final.jar"
+				MVN="mvn:org.talend.libraries/netty-all-4.0.29.Final/6.0.0"
+				UrlPath="platform:/plugin/org.talend.libraries.netty-all/lib/netty-all-4.0.29.Final.jar"
+				REQUIRED_IF="(HBASE_VERSION=='Cloudera_CDH5_8') AND (DISTRIBUTION!='CUSTOM')" />
 
 			<!-- Cloudera_CDH5_1 -->
 			<IMPORT MODULE_GROUP="HBASE-LIB-CDH_5_1_LASTEST"

--- a/main/plugins/org.talend.designer.components.bigdata/components/tHBaseConnection/tHBaseConnection_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tHBaseConnection/tHBaseConnection_java.xml
@@ -588,10 +588,6 @@
 				MVN="mvn:org.talend.libraries/netty-3.6.6.Final/6.0.0"
 				UrlPath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/netty-3.6.6.Final.jar"
 				REQUIRED_IF="HBASE_VERSION=='Cloudera_CDH5' AND (DISTRIBUTION!='CUSTOM')" />
-			<IMPORT NAME="netty-all-4.0.29.Final.jar" MODULE="netty-all-4.0.29.Final.jar"
-				MVN="mvn:org.talend.libraries/netty-all-4.0.29.Final/6.0.0"
-				UrlPath="platform:/plugin/org.talend.libraries.netty-all/lib/netty-all-4.0.29.Final.jar"
-				REQUIRED_IF="(HBASE_VERSION=='Cloudera_CDH5_8') AND (DISTRIBUTION!='CUSTOM')" />
 
 			<!-- Cloudera_CDH5_1 -->
 			<IMPORT MODULE_GROUP="HBASE-LIB-CDH_5_1_LASTEST"

--- a/main/plugins/org.talend.hadoop.distribution.cdh580/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.cdh580/plugin.xml
@@ -631,6 +631,7 @@
              <library id="jackson-mapper-asl-1.8.8.jar" />
              <library id="jackson-core-asl-1.8.8.jar" />
              <library id="netty-3.6.6.Final.jar" />
+             <library id="netty-all-4.0.23.Final.jar"/>
              <library id="protobuf-java-2.5.0.jar" />
              <library id="log4j-1.2.17.jar" />
              <library id="slf4j-api-1.7.5.jar" />


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

NoClassDefFoundError exception occured. Netty-all dependency is missing.

**What is the new behavior?**

Add netty-all dependency on tHBaseConnection component with CDH580.

**Other information**:
