### PR TITLE
fix(TBD-4869): add missing dependency declaration in CDH 5.7

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.cdh570/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.cdh570/plugin.xml
@@ -323,6 +323,13 @@
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.cdh570"
+            id="jackson-annotations-2.3.0.jar"
+            name="jackson-annotations-2.3.0.jar"
+            mvn_uri="mvn:org.talend.libraries/jackson-annotations-2.3.0/6.0.0">
+        </libraryNeeded>
+        
+        <libraryNeeded
+            context="plugin:org.talend.hadoop.distribution.cdh570"
             id="zookeeper-cdh5.7.0"
             name="zookeeper-3.4.5-cdh5.7.0.jar"
             mvn_uri="mvn:org.talend.libraries/zookeeper-3.4.5-cdh5.7.0/6.1.0">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

No download link shown regarding `jackson-annotations-2.3.0` while using CDH 5.7 Spark. This is caused by a missing dependency declaration in the distribution `plugin.xml` file.  

**What is the new behavior?**

`jackson-annotations-2.3.0` is now properly declared, and already present on Nexus. The jar download works.
