### PR TITLE
fix(TBD-4617): fix wrong dependency declaration in EMR 5.0.0 distribu…

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.emr500/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.emr500/plugin.xml
@@ -552,8 +552,8 @@
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.emr500"
             id="spark-streaming-kinesis-asl_2.11"
-            name="spark-streaming-kinesis-asl_2.11.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-streaming-kinesis-asl_2.11/6.0.0"/>    
+            name="spark-streaming-kinesis-asl_2.11-2.0.0.jar"
+            mvn_uri="mvn:org.talend.libraries/spark-streaming-kinesis-asl_2.11-2.0.0/6.0.0"/>    
             
         <libraryNeeded 
             context="plugin:org.talend.hadoop.distribution.emr500"

--- a/main/plugins/org.talend.hadoop.distribution.emr500/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.emr500/plugin.xml
@@ -551,7 +551,7 @@
             
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.emr500"
-            id="spark-streaming-kinesis-asl_2.11"
+            id="spark-streaming-kinesis-asl_2.11-emr500-latest"
             name="spark-streaming-kinesis-asl_2.11-2.0.0.jar"
             mvn_uri="mvn:org.talend.libraries/spark-streaming-kinesis-asl_2.11-2.0.0/6.0.0"/>    
             
@@ -1226,7 +1226,7 @@
                 id="SPARK-KINESIS-LIB-MRREQUIRED-EMR_5_0_0_LATEST"
                 name="SPARK-KINESIS-LIB-MRREQUIRED-EMR_5_0_0_LATEST">
             <!--<library id="spark-streaming-kinesis-asl-assembly-emr500-latest"/> -->
-            <library id="spark-streaming-kinesis-asl_2.11"/>
+            <library id="spark-streaming-kinesis-asl_2.11-emr500-latest"/>
             <library id="amazon-kinesis-client-1.2.1.jar"/>
             <library id="aws-java-sdk-kinesis-emr500-latest"/>
             <library id="aws-java-sdk-core-emr500-latest"/>            


### PR DESCRIPTION
…tion

**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

See https://jira.talendforge.org/browse/TBD-4617. 

Some jars are missing in Nexus but one of them is already there. It was simply wrongly declared in the EMR 5.0.0 distribution.

**What is the new behavior?**

The wrong declaration is fixed. The missing jars will be uploaded on Nexus outside of this PR.
