### PR TITLE
fix(TBD-5244): create dedicated module group for tGoogleDataprocManage

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.dataproc11/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.dataproc11/plugin.xml
@@ -10,6 +10,12 @@
             name="talend-bigdata-launcher-1.2.1-20170511.jar"
             mvn_uri="mvn:org.talend.libraries/talend-bigdata-launcher-1.2.1-20170511/6.0.0">
         </libraryNeeded>
+        <libraryNeeded
+            context="plugin:org.talend.hadoop.distribution.dataproc11"
+            id="talend-bigdata-launcher-1.2.2-20170613"
+            name="talend-bigdata-launcher-1.2.2-20170613.jar"
+            mvn_uri="mvn:org.talend.libraries/talend-bigdata-launcher-1.2.2-20170613/6.0.0">
+        </libraryNeeded>
 
         <libraryNeeded
 		    context="plugin:org.talend.hadoop.distribution.dataproc11"
@@ -482,6 +488,35 @@
 			<library id="jackson-core-asl-1.8.8" />
 			<library id="jackson-mapper-asl-1.8.8" />
 			<library id="commons-lang-2.6"/>
+        </libraryNeededGroup>
+        
+        <!-- tGoogleDataprocManage group -->
+        <libraryNeededGroup
+                description="tGoogleDataprocManage libraries for Dataproc 1.1"
+                id="GOOGLE-DATAPROC-MANAGE-LIB-DATAPROC11"
+                name="GOOGLE-DATAPROC-MANAGE-LIB-DATAPROC11"  >
+            <library id="talend-bigdata-launcher-1.2.2-20170613" />
+            <library id="google-api-client-1.22.0" />
+            <library id="google-api-client-appengine-1.21.0" />
+            <library id="google-api-client-servlet-1.21.0" />
+            <library id="google-api-services-storage-v1-rev85-1.22.0" />
+            <library id="google-api-services-dataproc-v1-rev46-1.22.0" />
+            <library id="google-http-client-1.21.0" />
+            <library id="google-http-client-appengine-1.21.0" />
+            <library id="google-http-client-jackson-1.21.0" />
+            <library id="google-http-client-jackson2-1.22.0" />
+            <library id="google-oauth-client-1.22.0" />
+            <library id="google-cloud-storage-0.9.4-beta" />
+            <library id="google-cloud-core-0.9.4-alpha" />
+            <library id="google-auth-library-credentials-0.6.0" />
+            <library id="google-auth-library-oauth2-http-0.6.0" />
+            <library id="gax-0.1.4" />
+            <library id="json-20151123" />
+            <library id="guava-19.0" />
+            <library id="jackson-core-2.2.3" />
+            <library id="jackson-core-asl-1.8.8" />
+            <library id="jackson-mapper-asl-1.8.8" />
+            <library id="commons-lang-2.6"/>
         </libraryNeededGroup>
 
         <!-- Hive group -->


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

`tGoogleDataprocManage` shares its `talend-bigdata-launcher` module group with the Dataproc 1.1 distribution.

**What is the new behavior?**

To fix https://jira.talendforge.org/browse/TBD-5244, changes were made on the `talend-bigdata-launcher`. 

Since we are really close to the 6.4.1 code freeze, a dedicated module group has been created for `tGoogleDataprocManage` not to take any chances to cause regressions on Dataproc 1.1 MapReduce and Spark. 

This new module group (with the updated `talend-bigdata-launcher`) is only used by `tGoogleDataprocManage`. 

**Other information**:

This PR must be merged alongside of https://github.com/Talend/tdi-studio-se/pull/1388
