### PR TITLE
fix(TBD-5208): add correct breeze dependencies in CDH 5.10 Spark 2

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.cdh5100/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.cdh5100/plugin.xml
@@ -1521,9 +1521,9 @@
              <library id="navigator-sdk-model-2.0-20160624" />
              <library id="spring-core-4.0.7.RELEASE"/>
              <library id="spring-web-4.0.7.RELEASE"/>
-             <!--library id="jackson-databind-2.2.3.jar"/-->
-             <!--library id="jackson-annotations-2.3.1"/-->
-             <!--library id="jackson-core-2.2.3.jar"/-->
+             <library id="jackson-databind-2.2.3.jar"/>
+             <library id="jackson-annotations-2.3.1"/>
+             <library id="jackson-core-2.2.3.jar"/>
              <library id="commons-net-3.1"/>
              <library id="jackson-datatype-joda-2.1.0"/>
              <library id="joda-time-2.5.jar"/>

--- a/main/plugins/org.talend.hadoop.distribution.cdh5100/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.cdh5100/plugin.xml
@@ -704,8 +704,8 @@
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5100spark2" id="arpack_combined_all-0.1.jar" name="arpack_combined_all-0.1.jar" mvn_uri="mvn:org.talend.libraries/arpack_combined_all-0.1/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5100spark2" id="blas-0.8.jar" name="blas-0.8.jar" mvn_uri="mvn:org.talend.libraries/blas-0.8/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5100spark2" id="bonecp-0.7.1.jar" name="bonecp-0.7.1.jar" mvn_uri="mvn:org.talend.libraries/bonecp-0.7.1/6.0.0"/>
-        <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5100spark2" id="breeze_2.11-0.11.2.jar" name="breeze_2.11-0.11.2.jar" mvn_uri="mvn:org.talend.libraries/breeze_2.11-0.11.2/6.0.0"/>
-        <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5100spark2" id="breeze-macros_2.11-0.11.2.jar" name="breeze-macros_2.11-0.11.2.jar" mvn_uri="mvn:org.talend.libraries/breeze-macros_2.11-0.11.2/6.0.0"/>
+        <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5100spark2" id="breeze_2.11-0.12.jar" name="breeze_2.11-0.12.jar" mvn_uri="mvn:org.talend.libraries/breeze_2.11-0.12/6.0.0"/>
+        <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5100spark2" id="breeze-macros_2.11-0.12.jar" name="breeze-macros_2.11-0.12.jar" mvn_uri="mvn:org.talend.libraries/breeze-macros_2.11-0.12/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5100spark2" id="calcite-avatica-1.2.0-incubating.jar" name="calcite-avatica-1.2.0-incubating.jar" mvn_uri="mvn:org.talend.libraries/calcite-avatica-1.2.0-incubating/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5100spark2" id="calcite-core-1.2.0-incubating.jar" name="calcite-core-1.2.0-incubating.jar" mvn_uri="mvn:org.talend.libraries/calcite-core-1.2.0-incubating/6.0.0"/>
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5100spark2" id="calcite-linq4j-1.2.0-incubating.jar" name="calcite-linq4j-1.2.0-incubating.jar" mvn_uri="mvn:org.talend.libraries/calcite-linq4j-1.2.0-incubating/6.0.0"/>
@@ -1193,8 +1193,8 @@
             <library id="avro-mapred-1.7.6-cdh5.10.1-hadoop2.jar"/>
             <library id="blas-0.8.jar"/>
             <library id="bonecp-0.7.1.jar"/>
-            <library id="breeze_2.11-0.11.2.jar"/>
-            <library id="breeze-macros_2.11-0.11.2.jar"/>
+            <library id="breeze_2.11-0.12.jar"/>
+            <library id="breeze-macros_2.11-0.12.jar"/>
             <library id="calcite-avatica-1.2.0-incubating.jar"/>
             <library id="calcite-core-1.2.0-incubating.jar"/>
             <library id="calcite-linq4j-1.2.0-incubating.jar"/>
@@ -1521,9 +1521,9 @@
              <library id="navigator-sdk-model-2.0-20160624" />
              <library id="spring-core-4.0.7.RELEASE"/>
              <library id="spring-web-4.0.7.RELEASE"/>
-             <library id="jackson-databind-2.2.3.jar"/>
-             <library id="jackson-annotations-2.3.1"/>
-             <library id="jackson-core-2.2.3.jar"/>
+             <!--library id="jackson-databind-2.2.3.jar"/-->
+             <!--library id="jackson-annotations-2.3.1"/-->
+             <!--library id="jackson-core-2.2.3.jar"/-->
              <library id="commons-net-3.1"/>
              <library id="jackson-datatype-joda-2.1.0"/>
              <library id="joda-time-2.5.jar"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

See https://jira.talendforge.org/browse/TBD-5208. This is caused by a wrong version of the `breeze` dependency in CDH 5.10 distribution.

**What is the new behavior?**

The `breeze` dependencies have been upgraded to 0.12, accordingly with https://github.com/cloudera/spark/blob/spark2-2.1.0-cloudera1/pom.xml#L704.

The relevant jars are already on Nexus.
