### PR TITLE
fix(TDI-39018):remove AGGREGATION_QUERY for tCosmosDBInput and hide

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tCosmosDBInput/tCosmosDBInput_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tCosmosDBInput/tCosmosDBInput_java.xml
@@ -222,7 +222,7 @@ Note : If you are running on a Sharded Cluster, please make sure to include the 
             NUM_ROW="45"
             NB_LINES="5"
             GROUP="QUERY_SPECS"
-            SHOW_IF="false AND (QUERY_TYPE=='AGGREGATION_QUERY)'">
+            SHOW="false">
             <ITEMS>
                 <ITEM NAME="AGGREGATION_STAGE" FIELD="TEXT" />
             </ITEMS>
@@ -275,7 +275,7 @@ Note : If you are running on a Sharded Cluster, please make sure to include the 
         </PARAMETER>
 
         <PARAMETER FIELD="CHECK" NAME="EXTERNAL_SORT_AGGREGATION"
-            NUM_ROW="50" GROUP="ADVANCED_AGGREGATION_OPTIONS" SHOW_IF="false AND (QUERY_TYPE=='AGGREGATION_QUERY')">
+            NUM_ROW="50" GROUP="ADVANCED_AGGREGATION_OPTIONS" SHOW="false">
             <DEFAULT>false</DEFAULT>
         </PARAMETER>
     </ADVANCED_PARAMETERS>

--- a/main/plugins/org.talend.designer.components.bigdata/components/tCosmosDBInput/tCosmosDBInput_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tCosmosDBInput/tCosmosDBInput_java.xml
@@ -191,7 +191,7 @@
             <DEFAULT>""</DEFAULT>
         </PARAMETER>
 
-        <PARAMETER NAME="QUERY_TYPE" FIELD="CLOSED_LIST" NUM_ROW="39" GROUP="QUERY_SPECS">
+        <PARAMETER NAME="QUERY_TYPE" FIELD="CLOSED_LIST" NUM_ROW="39" SHOW="false" GROUP="QUERY_SPECS">
             <ITEMS DEFAULT="FIND_QUERY">
                 <ITEM NAME="FIND_QUERY" VALUE="FIND_QUERY"/>
                 <ITEM NAME="AGGREGATION_QUERY" VALUE="AGGREGATION_QUERY"/>
@@ -222,7 +222,7 @@ Note : If you are running on a Sharded Cluster, please make sure to include the 
             NUM_ROW="45"
             NB_LINES="5"
             GROUP="QUERY_SPECS"
-            SHOW_IF="QUERY_TYPE=='AGGREGATION_QUERY'">
+            SHOW_IF="false AND (QUERY_TYPE=='AGGREGATION_QUERY)'">
             <ITEMS>
                 <ITEM NAME="AGGREGATION_STAGE" FIELD="TEXT" />
             </ITEMS>
@@ -275,7 +275,7 @@ Note : If you are running on a Sharded Cluster, please make sure to include the 
         </PARAMETER>
 
         <PARAMETER FIELD="CHECK" NAME="EXTERNAL_SORT_AGGREGATION"
-            NUM_ROW="50" GROUP="ADVANCED_AGGREGATION_OPTIONS" SHOW_IF="QUERY_TYPE=='AGGREGATION_QUERY'">
+            NUM_ROW="50" GROUP="ADVANCED_AGGREGATION_OPTIONS" SHOW_IF="false AND (QUERY_TYPE=='AGGREGATION_QUERY')">
             <DEFAULT>false</DEFAULT>
         </PARAMETER>
     </ADVANCED_PARAMETERS>


### PR DESCRIPTION
query type

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

CosmosDB doesn't support AGGREGATION_QUERY

**What is the new behavior?**

Remove AGGREGATION_QUERY for tCosmosDBInput and hide query type.

**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
