### PR TITLE
fix(TUP-18019)context group dialog popup manytimes when check service

### DIFF
--- a/main/plugins/org.talend.repository.hcatalog/src/org/talend/repository/hcatalog/ui/HCatalogForm.java
+++ b/main/plugins/org.talend.repository.hcatalog/src/org/talend/repository/hcatalog/ui/HCatalogForm.java
@@ -101,7 +101,7 @@ public class HCatalogForm extends AbstractHCatalogForm {
         }
 
         EHDFSRowSeparator rowSeparator = EHDFSRowSeparator.indexOf(ContextParameterUtils.getOriginalValue(
-                ConnectionContextHelper.getContextTypeForContextMode(getConnection()), rowSeparatorVal), false);
+                ConnectionContextHelper.getContextTypeForContextMode(getConnection(), true), rowSeparatorVal), false);
 
         if (rowSeparator != null) {
             rowSeparatorCombo.setText(rowSeparator.getDisplayName());
@@ -115,7 +115,7 @@ public class HCatalogForm extends AbstractHCatalogForm {
             getConnection().setFieldSeparator(fieldSeparatorVal);
         }
         EHDFSFieldSeparator fieldSeparator = EHDFSFieldSeparator.indexOf(ContextParameterUtils.getOriginalValue(
-                ConnectionContextHelper.getContextTypeForContextMode(getConnection()), fieldSeparatorVal), false);
+                ConnectionContextHelper.getContextTypeForContextMode(getConnection(), true), fieldSeparatorVal), false);
         if (fieldSeparator != null) {
             fieldSeparatorCombo.setText(fieldSeparator.getDisplayName());
         }

--- a/main/plugins/org.talend.repository.hdfs/src/org/talend/repository/hdfs/ui/HDFSForm.java
+++ b/main/plugins/org.talend.repository.hdfs/src/org/talend/repository/hdfs/ui/HDFSForm.java
@@ -86,7 +86,7 @@ public class HDFSForm extends AbstractHDFSForm {
             getConnection().setRowSeparator(rowSeparatorVal);
         }
         EHDFSRowSeparator rowSeparator = EHDFSRowSeparator.indexOf(ContextParameterUtils.getOriginalValue(
-                ConnectionContextHelper.getContextTypeForContextMode(getConnection()), rowSeparatorVal), false);
+                ConnectionContextHelper.getContextTypeForContextMode(getConnection(), true), rowSeparatorVal), false);
         if (rowSeparator != null) {
             rowSeparatorCombo.setText(rowSeparator.getDisplayName());
         }
@@ -99,7 +99,7 @@ public class HDFSForm extends AbstractHDFSForm {
             getConnection().setFieldSeparator(fieldSeparatorVal);
         }
         EHDFSFieldSeparator fieldSeparator = EHDFSFieldSeparator.indexOf(ContextParameterUtils.getOriginalValue(
-                ConnectionContextHelper.getContextTypeForContextMode(getConnection()), fieldSeparatorVal), false);
+                ConnectionContextHelper.getContextTypeForContextMode(getConnection(), true), fieldSeparatorVal), false);
         if (fieldSeparator != null) {
             fieldSeparatorCombo.setText(fieldSeparator.getDisplayName());
         }

--- a/main/plugins/org.talend.repository.hdfs/src/org/talend/repository/hdfs/util/HDFSModelUtil.java
+++ b/main/plugins/org.talend.repository.hdfs/src/org/talend/repository/hdfs/util/HDFSModelUtil.java
@@ -49,7 +49,7 @@ public class HDFSModelUtil {
     public static HDFSConnectionBean convert2HDFSConnectionBean(HDFSConnection connection) {
         ContextType contextType = null;
         if (connection.isContextMode()) {
-            contextType = ConnectionContextHelper.getContextTypeForContextMode(connection);
+            contextType = ConnectionContextHelper.getContextTypeForContextMode(connection, true);
         }
         HDFSConnectionBean bean = new HDFSConnectionBean();
         bean.setContextType(contextType);


### PR DESCRIPTION
*when have many context groups within Hive, Hbase, Hcate or HDFS, open
their wizard will not pop up select-context dialog now. 

*dialog will not appear when check service also.

https://jira.talendforge.org/browse/TUP-18019

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
