### PR TITLE
fix(TUP-18159):Compile error when same column names in different column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@
         <module>test/plugins/org.talend.oozie.scheduler.test</module>
         <module>test/plugins/org.talend.repository.nosql.test</module>
 		<module>test/plugins/org.talend.designer.pigmap.test</module>
+		<module>test/plugins/org.talend.repository.maprdbprovider.test</module>
         <module>test/plugins/org.talend.repository.hadoopcluster.configurator.test</module>
         <module>test/plugins/org.talend.repository.hadoopcluster.test</module>
         <module>test/plugins/org.talend.repository.hdfs.test</module>

--- a/test/features/org.talend.bigdata.se.test.feature/feature.xml
+++ b/test/features/org.talend.bigdata.se.test.feature/feature.xml
@@ -428,6 +428,14 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+         
+   <plugin
+         id="org.talend.repository.maprdbprovider.test"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
 
    <plugin
          id="org.talend.hadoop.distribution.cdh5100.test"

--- a/test/plugins/org.talend.repository.maprdbprovider.test/.classpath
+++ b/test/plugins/org.talend.repository.maprdbprovider.test/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/test/plugins/org.talend.repository.maprdbprovider.test/.project
+++ b/test/plugins/org.talend.repository.maprdbprovider.test/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.talend.repository.maprdbprovider.test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/test/plugins/org.talend.repository.maprdbprovider.test/META-INF/MANIFEST.MF
+++ b/test/plugins/org.talend.repository.maprdbprovider.test/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Test
+Bundle-SymbolicName: org.talend.repository.maprdbprovider.test
+Bundle-Version: 6.5.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Fragment-Host: org.talend.repository.maprdbprovider
+Require-Bundle: org.talend.testutils

--- a/test/plugins/org.talend.repository.maprdbprovider.test/build.properties
+++ b/test/plugins/org.talend.repository.maprdbprovider.test/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/test/plugins/org.talend.repository.maprdbprovider.test/pom.xml
+++ b/test/plugins/org.talend.repository.maprdbprovider.test/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.talend.studio</groupId>
+    <artifactId>tbd-studio-se</artifactId>
+    <version>6.5.0-SNAPSHOT</version>
+    <relativePath>../../../</relativePath>
+  </parent>
+  <artifactId>org.talend.repository.maprdbprovider.test</artifactId>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/test/plugins/org.talend.repository.maprdbprovider.test/src/org/talend/repository/maprdbprovider/test/MapRDBMetadataProviderTest.java
+++ b/test/plugins/org.talend.repository.maprdbprovider.test/src/org/talend/repository/maprdbprovider/test/MapRDBMetadataProviderTest.java
@@ -1,0 +1,59 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.repository.maprdbprovider.test;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.talend.repository.maprdbprovider.provider.MapRDBMetadataProvider;
+
+/**
+ * DOC hwang  class global comment. Detailled comment
+ */
+public class MapRDBMetadataProviderTest {
+    @Test
+    public void testGetUniqueColumnName() {
+        MapRDBMetadataProvider provider = new MapRDBMetadataProvider();
+        List<String> columnLabels = new ArrayList<String>();
+        String columnName = "columnName";
+        assertTrue(provider.getUniqueColumnName(columnLabels, columnName).equals(columnName));
+        
+        columnName = "column&^Name";
+        assertTrue(provider.getUniqueColumnName(columnLabels, columnName).equals("column__Name"));
+        
+        columnName = "public";
+        assertTrue(provider.getUniqueColumnName(columnLabels, columnName).equals("_public"));
+        
+        columnLabels = new ArrayList<String>();
+        columnLabels.add("columnName");
+        columnName = "columnName";
+        assertTrue(provider.getUniqueColumnName(columnLabels, columnName).equals("columnName1"));
+        
+        columnLabels = new ArrayList<String>();
+        columnLabels.add("columnName");
+        columnLabels.add("columnName1");
+        columnName = "columnName";
+        assertTrue(provider.getUniqueColumnName(columnLabels, columnName).equals("columnName2"));
+        
+        columnLabels = new ArrayList<String>();
+        columnLabels.add("column__Name");
+        columnLabels.add("column__Name1");
+        columnName = "column$$Name";
+        assertTrue(provider.getUniqueColumnName(columnLabels, columnName).equals("column__Name2"));
+        
+    }
+
+}


### PR DESCRIPTION
families in MapRDB

**Please check if the PR fulfills these requirements**

- [* ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ *] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [* ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

metadata Columns have the names

**What is the new behavior?**

when db Columns have the names, we will reset the metadata Column name,to make sure metadata Columns  do not have the names

**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
