### PR TITLE
Tdi 39056 extend types support handle nullable in DynamoDBOutput

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tDynamoDBOutput/tDynamoDBOutput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tDynamoDBOutput/tDynamoDBOutput_begin.javajet
@@ -20,250 +20,151 @@
   	String cid = node.getUniqueName();
 	
 	String region = ElementParameterParser.getValue(node, "__REGION__");
-
 	boolean useEndPoint = "true".equalsIgnoreCase(ElementParameterParser.getValue(node, "__USE_ENDPOINT__"));
-	
     String endPoint   = ElementParameterParser.getValue(node, "__ENDPOINT__");
-    
 	String dataAction = ElementParameterParser.getValue(node,"__DATA_ACTION__");
-	
 	String tableAction = ElementParameterParser.getValue(node,"__TABLE_ACTION__");
-	
 	String table   = ElementParameterParser.getValue(node, "__TABLE__");
-	
-	String hashKeyName = ElementParameterParser.getValue(node, "__PARTITION_KEY__");
-	String rangeKeyName = ElementParameterParser.getValue(node, "__SORT_KEY__");
-	
+	String partitionKey = ElementParameterParser.getValue(node, "__PARTITION_KEY__");
+	String sortKey = ElementParameterParser.getValue(node, "__SORT_KEY__");
 	long rcu = Long.parseLong(ElementParameterParser.getValue(node, "__RCU__"));
 	long wcu = Long.parseLong(ElementParameterParser.getValue(node, "__WCU__"));
-		
 	boolean isLog4jEnabled = ("true").equals(ElementParameterParser.getValue(node.getProcess(), "__LOG4J_ACTIVATE__"));
-	
+
+  	
   	List<IMetadataTable> outputMetadatas = node.getMetadataList();
-  	List<IMetadataColumn> outPutColumns = null;
-  	List<? extends IConnection> outputs = node.getOutgoingSortedConnections();
-  	String firstConnName = "";
-  	if (outputs.size() > 0){
-		IConnection out = outputs.get(0);
-		if(out!=null && out.getLineStyle().hasConnectionCategory(IConnectionCategory.DATA)){
-			firstConnName = out.getName();
+  	if(outputMetadatas == null || outputMetadatas.size() == 0 || outputMetadatas.get(0) == null){
+  		return "";
+  	}
+  	
+	IMetadataTable metadata = outputMetadatas.get(0);
+	List<IMetadataColumn> outPutColumns = metadata.getListColumns();
+%>
+
+int nb_line_<%=cid %> = 0;
+
+<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/Amazon/CredentialsProvider.javajet"%>
+
+com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient dynamoDBClient_<%=cid%> = new com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient(
+																					credentialsProvider_<%=cid%>,
+																					com.amazonaws.PredefinedClientConfigurations.dynamoDefault()
+																					.withUserAgent(routines.system.Constant.TALEND_USER_AGENT));
+ 
+<%	if(useEndPoint)	{	%>
+		dynamoDBClient_<%=cid%> = dynamoDBClient_<%=cid%>.withEndpoint(<%=endPoint%>);
+<%	} %>		
+
+<% 	if(!useEndPoint && region!=null && !region.isEmpty() && !"DEFAULT".equalsIgnoreCase(region)) {	%>
+		dynamoDBClient_<%=cid%>.setRegion(com.amazonaws.regions.RegionUtils.getRegion(<%=region%>));
+<%	} %>
+					
+com.amazonaws.services.dynamodbv2.document.DynamoDB dynamoDB_<%=cid%> = new com.amazonaws.services.dynamodbv2.document.DynamoDB(dynamoDBClient_<%=cid%>);
+com.amazonaws.services.dynamodbv2.document.Table table_<%=cid%> = dynamoDB_<%=cid%>.getTable(<%=table%>);
+
+<%	if(!"NONE".equalsIgnoreCase(tableAction))	{	%>
+
+		List<com.amazonaws.services.dynamodbv2.model.AttributeDefinition> attributeDefinitions_<%=cid%> = new java.util.ArrayList<com.amazonaws.services.dynamodbv2.model.AttributeDefinition>();
+		List<com.amazonaws.services.dynamodbv2.model.KeySchemaElement> keySchemaElements_<%=cid%> = new java.util.ArrayList<com.amazonaws.services.dynamodbv2.model.KeySchemaElement>();
+		
+		keySchemaElements_<%=cid%>.add(new com.amazonaws.services.dynamodbv2.model.KeySchemaElement(<%=partitionKey%>, com.amazonaws.services.dynamodbv2.model.KeyType.HASH));
+		
+		<% if(sortKey != null && !sortKey.isEmpty()) { %>
+			keySchemaElements_<%=cid%>.add(new com.amazonaws.services.dynamodbv2.model.KeySchemaElement(<%=sortKey%>, com.amazonaws.services.dynamodbv2.model.KeyType.RANGE));
+		<% } %>
+		
+	   <%
+		for (int i = 0; i < outPutColumns.size(); i++) {
+			IMetadataColumn column = outPutColumns.get(i);
+			if(column.isKey()) {				
+				JavaType javaType = JavaTypesManager.getJavaTypeFromId(column.getTalendType());
+				 // For the more details on the below type mapping
+				 // see http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBMapper.DataTypes.html
+				 //
+				 // String and Date type are converted to ScalarAttributeType.S
+				 // The Date values are stored as ISO-8601 formatted strings.
+				 // We use the Talend Date pattern defined by the user to store the date
+				 if (javaType == JavaTypesManager.STRING || javaType == JavaTypesManager.DATE) {
+		%>		
+					attributeDefinitions_<%=cid%>.add(new com.amazonaws.services.dynamodbv2.model.AttributeDefinition("<%=column.getLabel()%>", 
+					com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.S));
+				
+		<%
+				// All number types are converted to ScalarAttributeType.N
+				 } else if (javaType == JavaTypesManager.BIGDECIMAL
+                            || javaType == JavaTypesManager.LONG
+                            || javaType == JavaTypesManager.INTEGER
+                            || javaType == JavaTypesManager.SHORT
+                            || javaType == JavaTypesManager.DOUBLE
+                            || javaType == JavaTypesManager.FLOAT
+                            || javaType == JavaTypesManager.BOOLEAN) {
+		%>
+					attributeDefinitions_<%=cid%>.add(new com.amazonaws.services.dynamodbv2.model.AttributeDefinition("<%=column.getLabel()%>",
+					com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.N));			
+			<%	
+				}								
+			}
 		}
-    }
-	%>
-	int nb_line_<%=cid %> = 0;
-	
-	<%
-  	if(outputMetadatas != null && outputMetadatas.size() > 0){
-      	IMetadataTable metadata = outputMetadatas.get(0);
-      	if(metadata != null){
-			if ("INSERT".equalsIgnoreCase(dataAction)) {
-		%>
-				com.amazonaws.services.dynamodbv2.document.Item item_<%=cid%> = new com.amazonaws.services.dynamodbv2.document.Item(); 
-				com.amazonaws.services.dynamodbv2.document.spec.PutItemSpec putItemSpec_<%=cid%>;
-				com.amazonaws.services.dynamodbv2.document.PutItemOutcome putItemOutcome_<%=cid%>;
-		<%
-			}
-			else if ("UPDATE".equalsIgnoreCase(dataAction)) {			
-		%>
-				com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec updateItemSpec_<%=cid%> = new com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec();
-				com.amazonaws.services.dynamodbv2.document.UpdateItemOutcome updateItemOutcome_<%=cid%>;
-		<%
-			}
-			else if ("DELETE".equalsIgnoreCase(dataAction)) {				
-		%>
-				com.amazonaws.services.dynamodbv2.document.spec.DeleteItemSpec deleteItemSpec_<%=cid%> = new com.amazonaws.services.dynamodbv2.document.spec.DeleteItemSpec();
-				com.amazonaws.services.dynamodbv2.document.DeleteItemOutcome deleteItemOutcome_<%=cid%>;
-		<%
-			}
-		%>	
-			<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/Amazon/CredentialsProvider.javajet"%>
+	   
+} 
 
-			com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient dynamoDBClient_<%=cid%> = new com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient(
-				credentialsProvider_<%=cid%>,
-				com.amazonaws.PredefinedClientConfigurations.dynamoDefault().withUserAgent(routines.system.Constant.TALEND_USER_AGENT)
-			);
-   
-			<%
-			if(useEndPoint)
-			{
-			%>
-				dynamoDBClient_<%=cid%> = dynamoDBClient_<%=cid%>.withEndpoint(<%=endPoint%>);
-			<%
-			}		
-		
-			if(!useEndPoint && region!=null && !region.isEmpty() && !"DEFAULT".equalsIgnoreCase(region)){
-			%>
-				dynamoDBClient_<%=cid%>.setRegion(com.amazonaws.regions.RegionUtils.getRegion(<%=region%>));
-			<%
-			}
-		%>
-							
-			com.amazonaws.services.dynamodbv2.document.DynamoDB dynamoDB_<%=cid%> = new com.amazonaws.services.dynamodbv2.document.DynamoDB(dynamoDBClient_<%=cid%>);
-			
-			<%
-			if(!"NONE".equalsIgnoreCase(tableAction))
-			{
-				%>
-				List<com.amazonaws.services.dynamodbv2.model.AttributeDefinition> attributeDefinitionList_<%=cid%> = new java.util.ArrayList<com.amazonaws.services.dynamodbv2.model.AttributeDefinition>();
-				
-				List<com.amazonaws.services.dynamodbv2.model.KeySchemaElement> keyList_<%=cid%> = new java.util.ArrayList<com.amazonaws.services.dynamodbv2.model.KeySchemaElement>();
-				
-				keyList_<%=cid%>.add(new com.amazonaws.services.dynamodbv2.model.KeySchemaElement(<%=hashKeyName%>, com.amazonaws.services.dynamodbv2.model.KeyType.HASH));
-				
-				if(<%=rangeKeyName%> != null && !<%=rangeKeyName%>.isEmpty())
-				{	
-					keyList_<%=cid%>.add(new com.amazonaws.services.dynamodbv2.model.KeySchemaElement(<%=rangeKeyName%>, com.amazonaws.services.dynamodbv2.model.KeyType.RANGE));
-				}
-				
-				<%
-				outPutColumns = metadata.getListColumns();
-				int sizeColumns = outPutColumns.size();
-				
-				for (int i = 0; i < sizeColumns; i++) {
-					IMetadataColumn column = outPutColumns.get(i);
-					if(column.isKey()){				
-						String type = column.getTalendType();
-						if(type.toUpperCase().indexOf("STRING") >=0)
-						{
-					%>		
-							attributeDefinitionList_<%=cid%>.add(new com.amazonaws.services.dynamodbv2.model.AttributeDefinition("<%=column.getLabel()%>", com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.S));
-					<%	
-						}
-						else if(type.toUpperCase().indexOf("INTEGER") >= 0 || type.toUpperCase().indexOf("LONG") >= 0 )
-						{
-					%>		
-							attributeDefinitionList_<%=cid%>.add(new com.amazonaws.services.dynamodbv2.model.AttributeDefinition("<%=column.getLabel()%>", com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.N));			
-					<%	
-						}								
-					}
-				}
-			}
-			
-			if ("NONE".equalsIgnoreCase(tableAction)) {
-			%>
-		
-			<%
-			} else if ("CREATE".equalsIgnoreCase(tableAction)) {
-			%>
-				com.amazonaws.services.dynamodbv2.document.Table tableTemp_<%=cid%> = dynamoDB_<%=cid%>.createTable(
-					<%=table%>,
-					keyList_<%=cid%>,
-					attributeDefinitionList_<%=cid%>,
-					new com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput((long)<%=rcu%>, (long)<%=wcu%>));
-				tableTemp_<%=cid%>.waitForActive();
-				<%
-				if(isLog4jEnabled){
-				%>
-					log.info(<%=table%> + " has been created.");
-				<%
-				}
+if ("DROP_CREATE".equalsIgnoreCase(tableAction) || "DROP_IF_EXISTS_AND_CREATE".equalsIgnoreCase(tableAction)) {	%>
 
-			} else if ("CREATE_IF_NOT_EXISTS".equalsIgnoreCase(tableAction)) {
-			%>
-				try{
-					com.amazonaws.services.dynamodbv2.document.Table tableTemp_<%=cid%> = dynamoDB_<%=cid%>.getTable(<%=table%>);
+	<% if("DROP_IF_EXISTS_AND_CREATE".equalsIgnoreCase(tableAction)) { %>
+		try {
+	<% } %>
+				table_<%=cid%>.delete();
+				table_<%=cid%>.waitForDelete();
 				
-					
-					
-					tableTemp_<%=cid%> = dynamoDB_<%=cid%>.createTable(
-						<%=table%>,
-						keyList_<%=cid%>,
-						attributeDefinitionList_<%=cid%>,
-					new com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput((long)<%=rcu%>, (long)<%=wcu%>));
-					tableTemp_<%=cid%>.waitForActive();
-					<%
-					if(isLog4jEnabled){
-					%>
-						log.info(<%=table%> + " has been created.");
-					<%
-					}
-					%>
-				}
-				catch(com.amazonaws.services.dynamodbv2.model.ResourceInUseException ex)
-				{
-					<%
-					if(isLog4jEnabled){
-					%>
-						log.info(<%=table%> + " already exist.");
-					<%
-					}
-					%>
-				}
-				
-	
-			<%
-			} else if ("DROP_CREATE".equalsIgnoreCase(tableAction)) {
-			%>
-				com.amazonaws.services.dynamodbv2.document.Table tableTemp_<%=cid%> = dynamoDB_<%=cid%>.getTable(<%=table%>);
-				
-				tableTemp_<%=cid%>.delete();
-				tableTemp_<%=cid%>.waitForDelete();
-				<%
-				if(isLog4jEnabled){
-				%>
+				<%	if(isLog4jEnabled){ %>
 					log.info(<%=table%> + " has been deleted.");
-				<%
-				}
-				%>
+				<%	} %>
 				
-				tableTemp_<%=cid%> = dynamoDB_<%=cid%>.createTable(
-					<%=table%>,
-					keyList_<%=cid%>,
-					attributeDefinitionList_<%=cid%>,
-					new com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput((long)<%=rcu%>, (long)<%=wcu%>));
-				tableTemp_<%=cid%>.waitForActive();			
-				<%
-				if(isLog4jEnabled){
-				%>	
-					log.info(<%=table%> + " has been created.");
-				<%
-				}				
-
-			} else if ("DROP_IF_EXISTS_AND_CREATE".equalsIgnoreCase(tableAction)) {
-			%>
-				com.amazonaws.services.dynamodbv2.document.Table tableTemp_<%=cid%> = dynamoDB_<%=cid%>.getTable(<%=table%>);
-				
-				try{				
-					tableTemp_<%=cid%>.delete();
-					tableTemp_<%=cid%>.waitForDelete();
-					<%
-					if(isLog4jEnabled){
-					%>	
-						log.info(<%=table%> + " has been deleted.");
-					<%
-					}
-					%>					
-				}
-				catch(com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException ex)
-				{	
-					<%
-					if(isLog4jEnabled){
-					%>	
-						log.info(<%=table%> + " doesn't exist.");
-					<%
-					}
-					%>					
-				}
-
-				tableTemp_<%=cid%> = dynamoDB_<%=cid%>.createTable(
-					<%=table%>,
-					keyList_<%=cid%>,
-					attributeDefinitionList_<%=cid%>,
-					new com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput((long)<%=rcu%>, (long)<%=wcu%>));
-				tableTemp_<%=cid%>.waitForActive();				
-				<%
-				if(isLog4jEnabled){
-				%>	
-					log.info(<%=table%> + " has been created.");
-				<%
-				}
+	<%  //Handle error if table don't exist and option DROP_IF_EXISTS_AND_CREATE selected
+		if("DROP_IF_EXISTS_AND_CREATE".equalsIgnoreCase(tableAction)) {  %>
+			} catch(com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException ex) {	
+				<%	if(isLog4jEnabled) { %>	
+					log.info(<%=table%> + " doesn't exist.");
+				<% } %>					
 			}
-			%>			
-			com.amazonaws.services.dynamodbv2.document.Table table_<%=cid%> = dynamoDB_<%=cid%>.getTable(<%=table%>);
+	<% } %>
 
-				
-	<%						
+<% }
+
+// Create the table if necessary
+if(!"NONE".equalsIgnoreCase(tableAction))	{	%>
+
+	<% if("CREATE_IF_NOT_EXISTS".equalsIgnoreCase(tableAction)) { %>
+		try {
+	<% } %>
+	
+			table_<%=cid%> = dynamoDB_<%=cid%>.createTable(
+													<%=table%>,
+													keySchemaElements_<%=cid%>,
+													attributeDefinitions_<%=cid%>,
+													new com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput((long)<%=rcu%>, (long)<%=wcu%>));
+			table_<%=cid%>.waitForActive();				
+			<% if(isLog4jEnabled){ %>	
+				log.info(<%=table%> + " has been created.");
+			<%	} %>
+	
+	<% 
+	//Handle error if table exist and option create if not exist selected
+	if("CREATE_IF_NOT_EXISTS".equalsIgnoreCase(tableAction)) { %>
+		} catch(com.amazonaws.services.dynamodbv2.model.ResourceInUseException ex) {
+			<%	if(isLog4jEnabled) { %>
+				log.info(<%=table%> + " already exist.");
+			<%	} %>
 		}
-	} 
-	%>
+	<% } %>
+	
+<% } %>
 
+
+<% if ("INSERT".equalsIgnoreCase(dataAction)) {  %>
+		com.amazonaws.services.dynamodbv2.document.Item item_<%=cid%> = new com.amazonaws.services.dynamodbv2.document.Item(); 
+		com.amazonaws.services.dynamodbv2.document.spec.PutItemSpec putItemSpec_<%=cid%>;
+<% } else if ("UPDATE".equalsIgnoreCase(dataAction)) {	%>
+		com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec updateItemSpec_<%=cid%> = new com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec();
+<%	} else if ("DELETE".equalsIgnoreCase(dataAction)) { %>
+		com.amazonaws.services.dynamodbv2.document.spec.DeleteItemSpec deleteItemSpec_<%=cid%> = new com.amazonaws.services.dynamodbv2.document.spec.DeleteItemSpec();
+<%	} %>

--- a/main/plugins/org.talend.designer.components.bigdata/components/tDynamoDBOutput/tDynamoDBOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tDynamoDBOutput/tDynamoDBOutput_main.javajet
@@ -8,6 +8,8 @@
 		org.talend.core.model.metadata.IMetadataColumn
 		org.talend.core.model.metadata.IMetadataTable
 		org.talend.core.model.process.IConnectionCategory
+		org.talend.core.model.metadata.types.JavaTypesManager
+		org.talend.core.model.metadata.types.JavaType
 		java.util.List
 		java.util.Map
 "
@@ -16,261 +18,178 @@
 	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
 	INode node = (INode)codeGenArgument.getArgument();
 	String cid = node.getUniqueName();
-	
-	String dataAction = ElementParameterParser.getValue(node,"__DATA_ACTION__");
-
 	List<? extends IConnection> inConns = node.getIncomingConnections(EConnectionType.FLOW_MAIN);
+	
+	String dataAction 	= ElementParameterParser.getValue(node,"__DATA_ACTION__");
+	String partitionKey = ElementParameterParser.getValue(node, "__PARTITION_KEY__");
+	String sortKey 		= ElementParameterParser.getValue(node, "__SORT_KEY__");
+	List<Map<String, String>> nameMappingTable = (List<Map<String,String>>)ElementParameterParser.getObjectValue(node, "__NAME_MAPPING__");
+	boolean isLog4jEnabled = ("true").equals(ElementParameterParser.getValue(node.getProcess(), "__LOG4J_ACTIVATE__"));
+	
+	List<IMetadataTable> metadatas = node.getMetadataList();
+	List< ? extends IConnection> connections = node.getIncomingConnections();
+	if (connections == null || connections.size() == 0 || metadatas == null || metadatas.size() == 0){
+	    return "";
+	}
+	
+	List<IMetadataColumn> outPutColumns =  metadatas.get(0).getListColumns();
+	if (outPutColumns == null || outPutColumns.isEmpty()) {
+		return "";
+	}
+	
+	IConnection conn = connections.get(0);
+	if (!conn.getLineStyle().hasConnectionCategory(IConnectionCategory.DATA)) {
+		return "";
+	}
+%>
+	
+Object partitionKeyValue_<%=cid%>	= null;
+Object sortKeyValue_<%=cid%>	= null;
+java.util.Map<String, Object> mapValues_<%=cid%> = new java.util.HashMap<>();
 
-	String hashKeyName = ElementParameterParser.getValue(node, "__PARTITION_KEY__");
-	String rangeKeyName = ElementParameterParser.getValue(node, "__SORT_KEY__");
-	
-	List<Map<String, String>> nameMap = (List<Map<String,String>>)ElementParameterParser.getObjectValue(node, "__NAME_MAPPING__");
-	
+<% for (int i = 0; i < outPutColumns.size(); i++) { 
+		IMetadataColumn column = outPutColumns.get(i);
+		JavaType javaType = JavaTypesManager.getJavaTypeFromId(column.getTalendType());	
+		String name 		= "\""+column.getOriginalDbColumnName()+"\"";
+		String columnNode	= conn.getName() + "." + column.getLabel(); 			
+		boolean isDate		= (javaType == JavaTypesManager.DATE);
+		boolean isString	= (javaType == JavaTypesManager.STRING);
 		
-	IConnection inConn = null;
-	IMetadataTable metadata = null;
+		// This is the Hash Key
+		if(column.isKey() &&  name.equals(partitionKey)){ 
 	
-	if(inConns!=null && inConns.size()> 0) {
-		inConn = inConns.get(0);
-		metadata = inConn.getMetadataTable();
-	}
+			 if(isDate){ %>
+		 			partitionKeyValue_<%=cid%> = FormatterUtils.format_DateInUTC(<%=columnNode%>,  <%=column.getPattern()%>);
+			 <% } else { %>
+				 	partitionKeyValue_<%=cid%> = <%=columnNode%>;
+			 <% } 
+		
+		// This is the Range Key
+ 		}else if(column.isKey() &&  name.equals(sortKey)){
+ 			
+ 			if(isDate){ %>
+		 			sortKeyValue_<%=cid%> = FormatterUtils.format_DateInUTC(<%=columnNode%>,  <%=column.getPattern()%>);
+			 <% } else { %>
+				 	sortKeyValue_<%=cid%> = <%=columnNode%>;
+			 <% } 
+		
+ 		// Other row items 
+		}else {
+			   // Handle Nullable Items (also if String is empty we submitted as null)
+			   if(column.isNullable()){  %>
+			   
+			   		if(null == <%=columnNode%> <%if(isString) {%> || <%=columnNode%>.isEmpty() <%}%>) {
+			   			mapValues_<%=cid%>.put(<%=name%>, null);
+			   		}else {
+			   			<% if(isDate){ %>
+					 			mapValues_<%=cid%>.put(<%=name%>, FormatterUtils.format_DateInUTC(<%=columnNode%>,  <%=column.getPattern()%>));
+						 <% } else { %>
+							 	mapValues_<%=cid%>.put(<%=name%>, <%=columnNode%>);
+						 <% } %> 
+			   		}
+			<% }
+				// Handle the mandatory column (if columns are null or string empty we ignore them)  
+			   else { %>
+			   
+				   if(null != <%=columnNode%> <%if(isString) {%> && !<%=columnNode%>.isEmpty() <%}%>) {
+						<% if(isDate){ %>
+					 		mapValues_<%=cid%>.put(<%=name%>, FormatterUtils.format_DateInUTC(<%=columnNode%>,  <%=column.getPattern()%>));
+				 		<% } else { %>
+					 		mapValues_<%=cid%>.put(<%=name%>, <%=columnNode%>);
+						<% } %>
+				   }
+				   
+			<%   }
+		} 		
+ } 	
 	
-	List<IMetadataColumn> outPutColumns = null;
-	if( node.getMetadataList() != null && !node.getMetadataList().isEmpty()){
-		outPutColumns = node.getMetadataList().get(0).getListColumns();
-	}
-
-	if (metadata!=null && outPutColumns!=null && !outPutColumns.isEmpty()) {
-		List< ? extends IConnection> conns = node.getIncomingConnections();
-		for (IConnection conn : conns) {
-			if (conn.getLineStyle().hasConnectionCategory(IConnectionCategory.DATA)) {
-				
-				int sizeColumns = outPutColumns.size();
-
-				if(!"INSERT".equalsIgnoreCase(dataAction)){
-				%>
-					int countKey_<%=cid%>=0;
-					int countValue_<%=cid%>=0;
-				<%
-				}
-				
-				if ("INSERT".equalsIgnoreCase(dataAction)) {
-					%>	
-					Object hashKeyValue_<%=cid%> = null;
-					Object rangeKeyValue_<%=cid%> = null;
-					item_<%=cid%> = new com.amazonaws.services.dynamodbv2.document.Item();
-					<%
-					for (int i = 0; i < sizeColumns; i++) {
-						IMetadataColumn column = outPutColumns.get(i);
-						%>				
-						if (<%=conn.getName() %>.<%=column.getLabel() %> != null 
-							&& (!((Object) <%=conn.getName() %>.<%=column.getLabel() %> instanceof String) || !(String.valueOf(<%=conn.getName() %>.<%=column.getLabel() %>)).isEmpty())) {  				
-						<%
-						
-							if(column.isKey())
-							{	
-								%>							
-								if("<%=column.getOriginalDbColumnName()%>".equalsIgnoreCase(<%=hashKeyName%>))
-								{																		
-									hashKeyValue_<%=cid%> = <%=conn.getName() %>.<%=column.getLabel() %>;
-								}
-								else if(<%=rangeKeyName%>!=null && !<%=rangeKeyName%>.isEmpty() && "<%=column.getOriginalDbColumnName()%>".equalsIgnoreCase(<%=rangeKeyName%>))
-								{																		
-									rangeKeyValue_<%=cid%> = <%=conn.getName() %>.<%=column.getLabel() %>;
-								}
-								<%
-							}
-							else
-							{
-								%>
-								item_<%=cid%> = item_<%=cid%>.with("<%=column.getOriginalDbColumnName() %>", <%=conn.getName() %>.<%=column.getLabel() %>);
-							<%
-							}	
-							%>
-						}
-					<%			
-					}
-					
-					%>
-					if(<%=rangeKeyName%>!=null && !<%=rangeKeyName%>.isEmpty()){					
-						item_<%=cid%> = item_<%=cid%>.withPrimaryKey(<%=hashKeyName%>, hashKeyValue_<%=cid%>, <%=rangeKeyName%>, rangeKeyValue_<%=cid%>);				
-					}
-					else{
-						item_<%=cid%> = item_<%=cid%>.withPrimaryKey(<%=hashKeyName%>, hashKeyValue_<%=cid%>);
-					}
-					putItemSpec_<%=cid%> = new com.amazonaws.services.dynamodbv2.document.spec.PutItemSpec().withItem(item_<%=cid%>);
-                    				
-					<%
-					
-  				}
-				
-				if ("UPDATE".equalsIgnoreCase(dataAction)) {
-					%>
-					Object hashKeyValue_<%=cid%> = null;
-					Object rangeKeyValue_<%=cid%> = null;
-					
-					java.util.HashMap<String, Object> valueMap_<%=cid%> = new java.util.HashMap<String, Object>();	
-					java.util.HashMap<String,String> nameMap_<%=cid%> = new java.util.HashMap<String,String>();	
-					java.util.HashMap<String,String> nameMapRevert_<%=cid%> = new java.util.HashMap<String,String>();						
-					
-					<%	
-					for(Map<String,String> subNameMap : nameMap)
-					{
-						String placeholder = subNameMap.get("PLACEHOLDER");
-						String name = subNameMap.get("NAME");
-						%>
-							nameMap_<%=cid%>.put("<%=placeholder%>", "<%=name%>");
-							nameMapRevert_<%=cid%>.put("<%=name%>","<%=placeholder%>");
-						<%
-					}
-					%>
-					
-					StringBuffer updateExpressionBuffer_<%=cid%> = new StringBuffer();
-					updateExpressionBuffer_<%=cid%>.append("set ");
-					<%
-					for (int i = 0; i < sizeColumns; i++) {
-						IMetadataColumn column = outPutColumns.get(i);
-						
-						if(column.isKey()) 
-						{		
-							%>							
-							if("<%=column.getOriginalDbColumnName()%>".equalsIgnoreCase(<%=hashKeyName%>))
-							{																		
-								hashKeyValue_<%=cid%> = <%=conn.getName() %>.<%=column.getLabel() %>;
-							}
-							else if(<%=rangeKeyName%>!=null && !<%=rangeKeyName%>.isEmpty() && "<%=column.getOriginalDbColumnName()%>".equalsIgnoreCase(<%=rangeKeyName%>))
-							{																		
-								rangeKeyValue_<%=cid%> = <%=conn.getName() %>.<%=column.getLabel() %>;
-							}
-
-							countKey_<%=cid%>++;
-							<%
-						
-						}
-						else
-						{
-							%>
-							if(countValue_<%=cid%> > 0)
-							{
-								updateExpressionBuffer_<%=cid%>.append(", ");
-							}
-							
-							if(nameMapRevert_<%=cid%>.containsKey("<%=column.getOriginalDbColumnName() %>")){
-								updateExpressionBuffer_<%=cid%>.append(nameMapRevert_<%=cid%>.get("<%=column.getOriginalDbColumnName() %>"));
-								updateExpressionBuffer_<%=cid%>.append(" =:<%=column.getOriginalDbColumnName() %>");
-							}else{
-								updateExpressionBuffer_<%=cid%>.append("<%=column.getOriginalDbColumnName() %>  =:<%=column.getOriginalDbColumnName() %>");
-							}
-																			
-							valueMap_<%=cid%>.put(":<%=column.getOriginalDbColumnName() %>", <%=conn.getName() %>.<%=column.getLabel() %>);
-							countValue_<%=cid%>++;
-							
-						<%
-						}				
-					}
-			
-					%>
-					if(<%=rangeKeyName%>!=null && !<%=rangeKeyName%>.isEmpty()){					
-						updateItemSpec_<%=cid%> = updateItemSpec_<%=cid%>.withPrimaryKey(<%=hashKeyName%>, hashKeyValue_<%=cid%>, <%=rangeKeyName%>, rangeKeyValue_<%=cid%>);				
-					}
-					else{
-						updateItemSpec_<%=cid%> = updateItemSpec_<%=cid%>.withPrimaryKey(<%=hashKeyName%>, hashKeyValue_<%=cid%>);
-					}
-					
-					updateItemSpec_<%=cid%> = updateItemSpec_<%=cid%>.withUpdateExpression(updateExpressionBuffer_<%=cid%>.toString()).withValueMap(valueMap_<%=cid%>);	
-					
-					if(nameMap_<%=cid%>.size()>0)
-					{
-						updateItemSpec_<%=cid%> = updateItemSpec_<%=cid%>.withNameMap(nameMap_<%=cid%>);
-					}
-					<%
-					
-  				}
-				
-				if ("DELETE".equalsIgnoreCase(dataAction)) {
-					%>
-					Object hashKeyValue_<%=cid%> = null;
-					Object rangeKeyValue_<%=cid%> = null;
-					
-					<%
-					for (int i = 0; i < sizeColumns; i++) {
-						IMetadataColumn column = outPutColumns.get(i);
-
-						%>
-						if (<%=conn.getName() %>.<%=column.getLabel() %> != null) {
-   
-						<%
-						
-							if(column.isKey()) 
-							{	
-								%>							
-								if("<%=column.getOriginalDbColumnName()%>".equalsIgnoreCase(<%=hashKeyName%>))
-								{																		
-									hashKeyValue_<%=cid%> = <%=conn.getName() %>.<%=column.getLabel() %>;
-								}
-								else if(<%=rangeKeyName%>!=null && !<%=rangeKeyName%>.isEmpty() && "<%=column.getOriginalDbColumnName()%>".equalsIgnoreCase(<%=rangeKeyName%>))
-								{																		
-									rangeKeyValue_<%=cid%> = <%=conn.getName() %>.<%=column.getLabel() %>;
-								}
-
-								countKey_<%=cid%>++;
-								<%
-							
-							}
-							%>
-
-						}
-						
-						
-					<%			
-					}
-					%>
-					if(<%=rangeKeyName%>!=null && !<%=rangeKeyName%>.isEmpty()){					
-						deleteItemSpec_<%=cid%> = deleteItemSpec_<%=cid%>.withPrimaryKey(<%=hashKeyName%>, hashKeyValue_<%=cid%>, <%=rangeKeyName%>, rangeKeyValue_<%=cid%>);				
-					}
-					else{
-						deleteItemSpec_<%=cid%> = deleteItemSpec_<%=cid%>.withPrimaryKey(<%=hashKeyName%>, hashKeyValue_<%=cid%>);
-					}
-					<%
-  				}
-				
-
-				// INSERT operation
-				if ("INSERT".equalsIgnoreCase(dataAction)) {
-				%>									
-					putItemOutcome_<%=cid%> = table_<%=cid%>.putItem(putItemSpec_<%=cid%>);
-				<%
-				// Other operations (UPDATE, UPSERT, DELETE)
-				}else{
-				%>
-
-						<%
-						// UPDATE
-						if("UPDATE".equalsIgnoreCase(dataAction)){
-							%>
-							updateItemOutcome_<%=cid%> = table_<%=cid%>.updateItem(updateItemSpec_<%=cid%>);
-						<%							
-                        // UPSERT
-						} else if("UPSERT".equalsIgnoreCase(dataAction)){
-                          
-
-                        // DELETE
-                        } else if("DELETE".equalsIgnoreCase(dataAction)){
-							%>
-							deleteItemOutcome_<%=cid%> = table_<%=cid%>.deleteItem(deleteItemSpec_<%=cid%>);
-							<%							
-						}
-						%>
-
-				<%
-				}
-
-    			%>
-				nb_line_<%=cid %> ++;
-				
-				<%
-				
+if ("INSERT".equalsIgnoreCase(dataAction)) {	
+		
+		// Add resolved Primary keys to the Item
+		if(sortKey !=null && !sortKey.isEmpty()) { %>	
+				item_<%=cid%> = item_<%=cid%>.withPrimaryKey(<%=partitionKey%>, partitionKeyValue_<%=cid%>, 
+															 <%=sortKey%>, sortKeyValue_<%=cid%>);	
+		<% } else { %>
+				item_<%=cid%> = item_<%=cid%>.withPrimaryKey(<%=partitionKey%>, partitionKeyValue_<%=cid%>);
+		<% } %>
+		
+		for (java.util.Map.Entry<String, Object> entry : mapValues_<%=cid%>.entrySet()) {
+			if(entry.getValue() == null){
+				item_<%=cid%> = item_<%=cid%>.withNull(entry.getKey());
+			}else{
+				item_<%=cid%> = item_<%=cid%>.with(entry.getKey(), entry.getValue());
 			}
-		}
-	}
+		}	
+		putItemSpec_<%=cid%> = new com.amazonaws.services.dynamodbv2.document.spec.PutItemSpec().withItem(item_<%=cid%>);
+		table_<%=cid%>.putItem(putItemSpec_<%=cid%>);
+        
+		
+<% } else if ("UPDATE".equalsIgnoreCase(dataAction)) {	%>
+
+		<% if(sortKey !=null && !sortKey.isEmpty()){	%>				
+			updateItemSpec_<%=cid%> = updateItemSpec_<%=cid%>.withPrimaryKey(<%=partitionKey%>, partitionKeyValue_<%=cid%>,
+																			 <%=sortKey%>, sortKeyValue_<%=cid%>);				
+		<% } else { %>
+			updateItemSpec_<%=cid%> = updateItemSpec_<%=cid%>.withPrimaryKey(<%=partitionKey%>, partitionKeyValue_<%=cid%>);
+		<% } %>
+		
+		java.util.HashMap<String, Object> valueMap_<%=cid%> = new java.util.HashMap<String, Object>();	
+		java.util.HashMap<String,String> nameMap_<%=cid%> = new java.util.HashMap<String,String>();	
+		java.util.HashMap<String,String> nameMapRevert_<%=cid%> = new java.util.HashMap<String,String>();						
+		
+	<%	for(Map<String,String> mapping : nameMappingTable) {
+			String placeholder = mapping.get("PLACEHOLDER");
+			String name = mapping.get("NAME");
 	%>
+			nameMap_<%=cid%>.put("<%=placeholder%>", "<%=name%>");
+			nameMapRevert_<%=cid%>.put("<%=name%>","<%=placeholder%>");
+	<% 	} %>
+		
+		StringBuilder updateExpression_<%=cid%> = new StringBuilder();
+		updateExpression_<%=cid%>.append("set ");
+		int countValue_<%=cid%>=0;
+		for (java.util.Map.Entry<String, Object> entry : mapValues_<%=cid%>.entrySet()) {
+			if(countValue_<%=cid%> > 0)	{
+					updateExpression_<%=cid%>.append(", ");
+			}
+				
+			if(nameMapRevert_<%=cid%>.containsKey(entry.getKey())){
+					updateExpression_<%=cid%>.append(nameMapRevert_<%=cid%>.get(entry.getKey()));
+					updateExpression_<%=cid%>.append(" =:"+entry.getKey());
+			}else{
+					updateExpression_<%=cid%>.append(entry.getKey()+"  =:"+entry.getKey());
+			}
+																
+			valueMap_<%=cid%>.put(":"+entry.getKey(), entry.getValue());
+			countValue_<%=cid%>++;
+		}
+		
+		<%	if(isLog4jEnabled) { %>	
+			log.debug("update expression: "+updateExpression_<%=cid%>.toString());
+			log.debug("value map: "+nameMap_<%=cid%>.toString());
+			log.debug("value map: "+valueMap_<%=cid%>.toString());
+		<%	} %>
+		
+		updateItemSpec_<%=cid%> = updateItemSpec_<%=cid%>.withUpdateExpression(updateExpression_<%=cid%>.toString())
+														 .withValueMap(valueMap_<%=cid%>);	
+		if(nameMap_<%=cid%>.size()>0) {
+			updateItemSpec_<%=cid%> = updateItemSpec_<%=cid%>.withNameMap(nameMap_<%=cid%>);
+		}
+		
+		table_<%=cid%>.updateItem(updateItemSpec_<%=cid%>);
+		
+
+<% } else if ("DELETE".equalsIgnoreCase(dataAction)) { 	%>
+		
+		<% if(sortKey !=null && !sortKey.isEmpty()){	%>				
+			deleteItemSpec_<%=cid%> = deleteItemSpec_<%=cid%>.withPrimaryKey(<%=partitionKey%>, partitionKeyValue_<%=cid%>, 
+																			 <%=sortKey%>, sortKeyValue_<%=cid%>);				
+		<% }else { %>
+			deleteItemSpec_<%=cid%> = deleteItemSpec_<%=cid%>.withPrimaryKey(<%=partitionKey%>, partitionKeyValue_<%=cid%>);
+		<% } %>
+		
+		table_<%=cid%>.deleteItem(deleteItemSpec_<%=cid%>);
+<% } %>
+	 
+nb_line_<%=cid %> ++;
+		

--- a/main/plugins/org.talend.designer.components.bigdata/components/tDynamoDBOutput/tDynamoDBOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tDynamoDBOutput/tDynamoDBOutput_main.javajet
@@ -54,6 +54,7 @@ java.util.Map<String, Object> mapValues_<%=cid%> = new java.util.HashMap<>();
 		String columnNode	= conn.getName() + "." + column.getLabel(); 			
 		boolean isDate		= (javaType == JavaTypesManager.DATE);
 		boolean isString	= (javaType == JavaTypesManager.STRING);
+		boolean isByteArray	= (javaType == JavaTypesManager.BYTE_ARRAY);
 		
 		// This is the Hash Key
 		if(column.isKey() &&  name.equals(partitionKey)){ 
@@ -76,9 +77,9 @@ java.util.Map<String, Object> mapValues_<%=cid%> = new java.util.HashMap<>();
  		// Other row items 
 		}else {
 			   // Handle Nullable Items (also if String is empty we submitted as null)
-			   if(column.isNullable()){  %>
+			   if(column.isNullable()) {  %>
 			   
-			   		if(null == <%=columnNode%> <%if(isString) {%> || <%=columnNode%>.isEmpty() <%}%>) {
+			   		if(null == <%=columnNode%> <%if(isString) {%> || <%=columnNode%>.isEmpty() <%}%> <%if(isByteArray) {%> || <%=columnNode%>.length == 0 <%}%>) {
 			   			mapValues_<%=cid%>.put(<%=name%>, null);
 			   		}else {
 			   			<% if(isDate){ %>
@@ -91,7 +92,7 @@ java.util.Map<String, Object> mapValues_<%=cid%> = new java.util.HashMap<>();
 				// Handle the mandatory column (if columns are null or string empty we ignore them)  
 			   else { %>
 			   
-				   if(null != <%=columnNode%> <%if(isString) {%> && !<%=columnNode%>.isEmpty() <%}%>) {
+				   if(null != <%=columnNode%> <%if(isString) {%> && !<%=columnNode%>.isEmpty() <%}%> <%if(isByteArray) {%> && <%=columnNode%>.length != 0 <%}%>) {
 						<% if(isDate){ %>
 					 		mapValues_<%=cid%>.put(<%=name%>, FormatterUtils.format_DateInUTC(<%=columnNode%>,  <%=column.getPattern()%>));
 				 		<% } else { %>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-39056

**What is the new behavior?**
Add Support of Talend Types:
Date type are formatted to String using the user pattern and stored to dynamodb as a String (the supported dynamodb format for date)

Nullable columns are submited to dynamodb as Null(DynamoDB type)
If column is of type String or byte[] and is nullable. If the column value is empty we also submit it as Null (DynamoDB type).

If the column are non Nullable and the column value are Null (or Empty in case of String, byte[] type) we ignore them in the insertion.
DynamoDB expect Attribute values to not be null. String and Binary type attributes must have lengths greater than zero.

**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
