### PR TITLE
fix(TBD-5540/components): fixed (tETLHiveMap cannot have carriage returns in the syntax)

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tELTHiveMap/tELTHiveMap_main.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tELTHiveMap/tELTHiveMap_main.javajet
@@ -264,7 +264,7 @@
 				String getQueryColumnsSegments() {
 					return new StringBuilder()
         				<%for(String segment : queryColumnsSegments) {%>
-        				.append("<%=segment%>")
+        				.append("<%=segment.replaceAll("[\r\n]", " ")%>")
         				<%}%>
         				.toString();
 				}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [X] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [X] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?
- [X] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
tETLHiveMap generates compilation error if contains carriage returns in the SQL
https://jira.talendforge.org/browse/TBD-5540

**What is the new behavior?**
tETLHiveMap generates correct code if contains carriage returns in the SQL
