### PR TITLE
feat(TBD-4197): set hive query name for tracking

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tELTHiveOutput/tELTHiveOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tELTHiveOutput/tELTHiveOutput_main.javajet
@@ -792,6 +792,7 @@ if(columnList != null && columnList.size()>0){
         }
         if (!hiveDistrib.useCloudLauncher()) {
 %>
+			<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/Hive/SetQueryName.javajet"%>
             stmt_<%=cid %>.execute(insertQuery_<%=cid %>);
 <%
         } else if(hiveDistrib.isExecutedThroughWebHCat()) {
@@ -814,6 +815,7 @@ if(columnList != null && columnList.size()>0){
         }
         if (!hiveDistrib.useCloudLauncher()) {
 %>
+			<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/Hive/SetQueryName.javajet"%>
             stmt_<%=cid %>.execute(overwriteQuery_<%=cid %>);
 
 <%

--- a/main/plugins/org.talend.designer.components.bigdata/components/tHiveCreateTable/tHiveCreateTable_main.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tHiveCreateTable/tHiveCreateTable_main.javajet
@@ -305,6 +305,7 @@ if(likeTable) {
         if(!hiveDistrib.useCloudLauncher()) {
 %>
             try {
+				<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/Hive/SetQueryName.javajet"%>
                 stmt_<%=cid%>.execute(querySQL_<%=cid %>);
             } catch(java.sql.SQLException e_<%=cid%>) {
                 <%if(("true").equals(dieOnError)) {%>
@@ -648,6 +649,7 @@ String querySQL_<%=cid %> = "<%=createTableSQL.toString()%>";
     if(!hiveDistrib.useCloudLauncher()) {
 %>
 try {
+	<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/Hive/SetQueryName.javajet"%>
     stmt_<%=cid%>.execute(querySQL_<%=cid %>);
 } catch(java.sql.SQLException e_<%=cid%>) {
 <%

--- a/main/plugins/org.talend.designer.components.bigdata/components/tHiveInput/tHiveInput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tHiveInput/tHiveInput_begin.javajet
@@ -709,6 +709,13 @@ imports="
 			// End of parquet format handling.
 
 			super.createStatement(node);
+			%>
+			try {
+				<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/Hive/SetQueryName.javajet"%>
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			<%
 		}
 
 	}//end class

--- a/main/plugins/org.talend.designer.components.bigdata/components/tHiveLoad/tHiveLoad_main.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tHiveLoad/tHiveLoad_main.javajet
@@ -263,13 +263,12 @@ imports="
 
 %>
     <%@ include file="@{org.talend.designer.components.bigdata}/components/tHiveLoad/loadQueryGeneration.javajet"%>
-<%
+	<%
     if(!hiveDistrib.useCloudLauncher()) {
-%>
-
+    %>
         java.sql.Statement stmt_<%=cid %> = conn_<%=cid %>.createStatement();
-
         try {
+			<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/Hive/SetQueryName.javajet"%>
             stmt_<%=cid%>.execute(querySQL_<%=cid %>);
         } catch(java.sql.SQLException e_<%=cid%>) {
             <%if(("true").equals(dieOnError)) {


### PR DESCRIPTION
This PR totally depends on https://github.com/Talend/tdi-studio-se/pull/1646.

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**
Be able to get hive query name (to monitor it on yarn or Tez) while running Hive job including tHiveInput, tHiveLoad, tHiveCreateTable or tELTHiveOutput.


**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
