### PR TITLE
fix(TBD-5578/components): tImportSqoop fails Against Vertica JDBC driver

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tSqoopImport/tSqoopImport_javaapi.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tSqoopImport/tSqoopImport_javaapi.javajet
@@ -71,6 +71,7 @@
 	String split = ElementParameterParser.getValue(node,"__SPLIT__");
 	
 	String fsDefalutName = "fs.default.name";
+    String driverClass = ElementParameterParser.getValue(node, "__DRIVER_CLASS__");
 	
 	boolean dieOnError = "true".equals(ElementParameterParser.getValue(node, "__DIE_ON_ERROR__"));
 	String passwordFieldName = "";
@@ -91,6 +92,7 @@
 	com.cloudera.sqoop.SqoopOptions sqoopOptions_<%=cid%> = new com.cloudera.sqoop.SqoopOptions(configuration_<%=cid%>);
 	sqoopOptions_<%=cid%>.setConnectString(<%=connection%>); // __CONNECTION__
 	sqoopOptions_<%=cid%>.setUsername(<%=username%>); // __USERNAME__
+	sqoopOptions_<%=cid%>.setDriverClassName(<%=driverClass%>);//driver class name
 	
    <%if(!passwordStoredInFile || !sqoopDistrib.doJavaAPISupportStorePasswordInFile()) {%>
 		<%


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [X] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [X] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?
- [X] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
Vertica JDBC driver is not loaded when trying to use tSqoopImport component with vertica driver.
https://jira.talendforge.org/browse/TBD-5578

**What is the new behavior?**
Vertica JDBC driver is loaded succesfully