### PR TITLE
Cannot set tkafkacreatetopic component retention time with context variable

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tKafkaCreateTopic/0.10.0.x/tKafkaCreateTopic_begin_0.10.0.x.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tKafkaCreateTopic/0.10.0.x/tKafkaCreateTopic_begin_0.10.0.x.javajet
@@ -10,7 +10,7 @@ java.util.Properties <%=cid%>_topicProperties = new java.util.Properties();
 <%
 	if(tKafkaCreateTopicUtil.isRetentionSet()) {
 %>
-		<%=cid%>_topicProperties.put("retention.ms", "<%=tKafkaCreateTopicUtil.getRetention()%>");
+		<%=cid%>_topicProperties.put("retention.ms", new java.lang.StringBuilder().append(<%=tKafkaCreateTopicUtil.getRetention()%>).toString());
 <%
 	}
 %>

--- a/main/plugins/org.talend.designer.components.bigdata/components/tKafkaCreateTopic/0.8.2.x/tKafkaCreateTopic_begin_0.8.2.x.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tKafkaCreateTopic/0.8.2.x/tKafkaCreateTopic_begin_0.8.2.x.javajet
@@ -10,7 +10,7 @@ java.util.Properties <%=cid%>_topicProperties = new java.util.Properties();
 <%
 	if(tKafkaCreateTopicUtil.isRetentionSet()) {
 %>
-		<%=cid%>_topicProperties.put("retention.ms", "<%=tKafkaCreateTopicUtil.getRetention()%>");
+		<%=cid%>_topicProperties.put("retention.ms", new java.lang.StringBuilder().append(<%=tKafkaCreateTopicUtil.getRetention()%>).toString());
 <%
 	}
 %>

--- a/main/plugins/org.talend.designer.components.bigdata/components/tKafkaCreateTopic/0.9.0.x/tKafkaCreateTopic_begin_0.9.0.x.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tKafkaCreateTopic/0.9.0.x/tKafkaCreateTopic_begin_0.9.0.x.javajet
@@ -10,7 +10,7 @@ java.util.Properties <%=cid%>_topicProperties = new java.util.Properties();
 <%
 	if(tKafkaCreateTopicUtil.isRetentionSet()) {
 %>
-		<%=cid%>_topicProperties.put("retention.ms", "<%=tKafkaCreateTopicUtil.getRetention()%>");
+		<%=cid%>_topicProperties.put("retention.ms", new java.lang.StringBuilder().append(<%=tKafkaCreateTopicUtil.getRetention()%>).toString());
 <%
 	}
 %>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

[TBD-5803](https://jira.talendforge.org/browse/TBD-5803)
retention time can only be a number, this prevent a context variable from being used

**What is the new behavior?**

retention time can be a number or a string.
