### PR TITLE
fix(TBD-5781): handle tKafkaOutput exceptions

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tKafkaInput/0.10.0.x/tKafkaInput_end_0.10.0.x.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tKafkaInput/0.10.0.x/tKafkaInput_end_0.10.0.x.javajet
@@ -1,3 +1,5 @@
+<%@ jet %>
+
 <%
 	// This is the tKafkaInput_end javajet part for Kafka 0.9.0.x
 	

--- a/main/plugins/org.talend.designer.components.bigdata/components/tKafkaInput/0.8.2.x/tKafkaInput_end_0.8.2.x.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tKafkaInput/0.8.2.x/tKafkaInput_end_0.8.2.x.javajet
@@ -1,3 +1,5 @@
+<%@ jet %>
+
 <%
 	// This is the tKafkaInput_end javajet part for Kafka 0.8.2.x
 	

--- a/main/plugins/org.talend.designer.components.bigdata/components/tKafkaInput/0.9.0.x/tKafkaInput_end_0.9.0.x.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tKafkaInput/0.9.0.x/tKafkaInput_end_0.9.0.x.javajet
@@ -1,3 +1,5 @@
+<%@ jet %>
+
 <%
 	// This is the tKafkaInput_end javajet part for Kafka 0.9.0.x
 	

--- a/main/plugins/org.talend.designer.components.bigdata/components/tKafkaOutput/tKafkaOutput_end.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tKafkaOutput/tKafkaOutput_end.javajet
@@ -21,3 +21,8 @@ String cid = node.getUniqueName();
 //%cid%_kafkaProducer.close();
 %>
 
+synchronized (producerException) {
+	while (producerException.containsKey("exception"))
+		if (producerException.get("exception") != null)
+			throw producerException.get("exception");
+}

--- a/main/plugins/org.talend.designer.components.bigdata/components/tKafkaOutput/tKafkaOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tKafkaOutput/tKafkaOutput_main.javajet
@@ -26,6 +26,15 @@ final TKafkaOutputUtil tKafkaOutputUtil = new TKafkaOutputUtil(node);
 final String cid = node.getUniqueName();
 %>
 
-<%=cid%>_kafkaProducer.send(new org.apache.kafka.clients.producer.ProducerRecord<byte[], byte[]>(<%=tKafkaOutputUtil.getKafkaTopic()%>, <%=tKafkaOutputUtil.getIncomingConnection().getName()%>.<%=tKafkaOutputUtil.getIncomingColumnName()%>));
+final java.util.HashMap<String, Exception> producerException = new java.util.HashMap<>();
 
-
+<%=cid%>_kafkaProducer.send(new org.apache.kafka.clients.producer.ProducerRecord<byte[], byte[]>(<%=tKafkaOutputUtil.getKafkaTopic()%>, <%=tKafkaOutputUtil.getIncomingConnection().getName()%>.<%=tKafkaOutputUtil.getIncomingColumnName()%>), new org.apache.kafka.clients.producer.Callback() {
+	public void onCompletion(org.apache.kafka.clients.producer.RecordMetadata metadata, Exception e) {
+		synchronized (producerException) {
+			producerException.put("exception", null);
+			if (e != null) {
+				producerException.put("exception", e);
+			}
+		}
+	}
+});


### PR DESCRIPTION
Previously we didn't effectively handle the kafka producer exceptions
because async behaviour of the producer's send method. So we catched it
by creating a Callback then pass back and throw it up in our main thread.

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TBD-5781


**What is the new behavior?**
Exceptions for tKafkaOutput can be catched and handled.


**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
