### PR TITLE
fix(TUP-18774): retrieve schema from HDFS ( Encrypted zone) remains on Pending

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.hdp250/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.hdp250/plugin.xml
@@ -1204,11 +1204,11 @@
       </classloader>    
       <classloader
             index="HDFS:HORTONWORKS:HDP_2_5"
-            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-io-2.4.jar;commons-configuration-1.6.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;guava-11.0.2.jar;hadoop-auth-2.7.3.2.5.0.0-1245.jar;hadoop-common-2.7.3.2.5.0.0-1245.jar;hadoop-hdfs-2.7.3.2.5.0.0-1245.jar;htrace-core-3.1.0-incubating.jar;jersey-core-1.9.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;jackson-core-asl-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;commons-codec-1.4.jar">
+            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-io-2.4.jar;commons-configuration-1.6.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;guava-11.0.2.jar;hadoop-auth-2.7.3.2.5.0.0-1245.jar;hadoop-common-2.7.3.2.5.0.0-1245.jar;hadoop-hdfs-2.7.3.2.5.0.0-1245.jar;htrace-core-3.1.0-incubating.jar;jersey-core-1.9.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;jackson-core-asl-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;commons-codec-1.4.jar;httpclient-4.5.2.jar;httpcore-4.4.4.jar">
       </classloader>   
       <classloader
             index="HDFS:HORTONWORKS:HDP_2_5?USE_KRB"
-            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-io-2.4.jar;commons-configuration-1.6.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;guava-11.0.2.jar;hadoop-auth-2.7.3.2.5.0.0-1245.jar;hadoop-common-2.7.3.2.5.0.0-1245.jar;hadoop-hdfs-2.7.3.2.5.0.0-1245.jar;htrace-core-3.1.0-incubating.jar;jersey-core-1.9.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;jackson-core-asl-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;hadoop-conf-kerberos.jar;commons-codec-1.4.jar">
+            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-io-2.4.jar;commons-configuration-1.6.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;guava-11.0.2.jar;hadoop-auth-2.7.3.2.5.0.0-1245.jar;hadoop-common-2.7.3.2.5.0.0-1245.jar;hadoop-hdfs-2.7.3.2.5.0.0-1245.jar;htrace-core-3.1.0-incubating.jar;jersey-core-1.9.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;jackson-core-asl-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;hadoop-conf-kerberos.jar;commons-codec-1.4.jar;httpclient-4.5.2.jar;httpcore-4.4.4.jar">
       </classloader>               
     </extension>
 </plugin>

--- a/main/plugins/org.talend.hadoop.distribution.hdp260/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.hdp260/plugin.xml
@@ -1789,11 +1789,11 @@
       </classloader>    
       <classloader
             index="HDFS:HORTONWORKS:HDP_2_6"
-            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-io-2.4.jar;commons-configuration-1.6.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;guava-11.0.2.jar;hadoop-auth-2.7.3.2.5.0.0-1245.jar;hadoop-common-2.7.3.2.5.0.0-1245.jar;hadoop-hdfs-2.7.3.2.5.0.0-1245.jar;htrace-core-3.1.0-incubating.jar;jersey-core-1.9.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;jackson-core-asl-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;commons-codec-1.4.jar">
+            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-io-2.4.jar;commons-configuration-1.6.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;guava-11.0.2.jar;hadoop-auth-2.7.3.2.5.0.0-1245.jar;hadoop-common-2.7.3.2.5.0.0-1245.jar;hadoop-hdfs-2.7.3.2.5.0.0-1245.jar;htrace-core-3.1.0-incubating.jar;jersey-core-1.9.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;jackson-core-asl-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;commons-codec-1.4.jar;httpclient-4.5.2.jar;httpcore-4.4.4.jar">
       </classloader>   
       <classloader
             index="HDFS:HORTONWORKS:HDP_2_6?USE_KRB"
-            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-io-2.4.jar;commons-configuration-1.6.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;guava-11.0.2.jar;hadoop-auth-2.7.3.2.5.0.0-1245.jar;hadoop-common-2.7.3.2.5.0.0-1245.jar;hadoop-hdfs-2.7.3.2.5.0.0-1245.jar;htrace-core-3.1.0-incubating.jar;jersey-core-1.9.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;jackson-core-asl-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;hadoop-conf-kerberos.jar;commons-codec-1.4.jar">
+            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-io-2.4.jar;commons-configuration-1.6.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;guava-11.0.2.jar;hadoop-auth-2.7.3.2.5.0.0-1245.jar;hadoop-common-2.7.3.2.5.0.0-1245.jar;hadoop-hdfs-2.7.3.2.5.0.0-1245.jar;htrace-core-3.1.0-incubating.jar;jersey-core-1.9.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;jackson-core-asl-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;hadoop-conf-kerberos.jar;commons-codec-1.4.jar;httpclient-4.5.2.jar;httpcore-4.4.4.jar">
       </classloader>               
     </extension>
 </plugin>


### PR DESCRIPTION
fix(TUP-18774): retrieve schema from HDFS ( Encrypted zone) remains on Pending
https://jira.talendforge.org/browse/TUP-18774

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [x] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
