### PR TITLE
fix(TUP-19187) Set onboarding for talend products only

### DIFF
--- a/main/features/org.talend.rcp.branding.tos.bigdata.feature/feature.xml
+++ b/main/features/org.talend.rcp.branding.tos.bigdata.feature/feature.xml
@@ -59,6 +59,36 @@
          unpack="false"/>
 
    <plugin
+         id="org.talend.presentation.onboarding"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.talend.presentation.onboarding.nl"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.talend.presentation.onboarding.resource"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.talend.presentation.onboarding.resource.nl"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
          id="org.talend.presentation.onboarding.resource.tos"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
onboarding is available for every products, even oems.
They should be on talend products only


**What is the new behavior?**
Set onboarding in the talend product feature directly