### PR TITLE
fix(TDI-39966) : DynamoDB empty string is empty json

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tDynamoDBOutput/tDynamoDBOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tDynamoDBOutput/tDynamoDBOutput_main.javajet
@@ -133,7 +133,9 @@ if ("INSERT".equalsIgnoreCase(dataAction)) {
 				item_<%=cid%> = item_<%=cid%>.withNull(entry.getKey());
 			}else{
 			    if(dbTypeJSONMap_<%=cid%>.get(entry.getKey())){
-			        item_<%=cid%> = item_<%=cid%>.withJSON(entry.getKey(), entry.getValue().toString());
+			        String json_value_<%=cid%> = entry.getValue().toString().trim();
+			        json_value_<%=cid%> = (json_value_<%=cid%>.isEmpty()) ? "{}" : json_value_<%=cid%>;
+			        item_<%=cid%> = item_<%=cid%>.withJSON(entry.getKey(), json_value_<%=cid%>);
 			    }
 			    else{
 				    item_<%=cid%> = item_<%=cid%>.with(entry.getKey(), entry.getValue());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-39966

**What is the new behavior?**
If an empty String "" is given to a JSON db type field, then empty json "{}" is sent to dynamodb.


**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
