### PR TITLE
fix(TUP-19329):Dyanmic: when Import two dynamic configuration, second one cann't check success.

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/dynamic/DynamicDistributionManager.java
+++ b/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/dynamic/DynamicDistributionManager.java
@@ -593,4 +593,9 @@ public class DynamicDistributionManager implements IDynamicDistributionManager {
         }
         return dynamicDistributionPreferencePaths;
     }
+
+    @Override
+    public String getDynamicDistributionCacheVersion() {
+        return HadoopDistributionsHelper.getCacheVersion();
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
Dyanmic: when Import two dynamic configuration, create hadoop cluster then select second one as distribution, cann't check success.

**What is the new behavior?**
Dyanmic: when Import two dynamic configuration, create hadoop cluster then select second one as distribution, cann check success now.
