### PR TITLE
fix(TBD-4424):Redshift components need avro 1.7.6+

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.emr450/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.emr450/plugin.xml
@@ -58,6 +58,12 @@
             name="hadoop-yarn-common-2.7.2-amzn-0.jar" 
             mvn_uri="mvn:org.talend.libraries/hadoop-yarn-common-2.7.2-amzn-0/6.2.0"/>
             
+        <libraryNeeded
+            context="plugin:org.talend.hadoop.distribution.emr450"
+            id="avro-1.7.6.jar"
+            name="avro-1.7.6.jar"
+            mvn_uri="mvn:org.talend.libraries/avro-1.7.6/6.0.0"/>            
+            
         <!-- HBase libraries (EMR 4.6.0 only) -->
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.emr450"
@@ -364,7 +370,7 @@
              <library id="emr-metrics-client-emr450-latest"/>
              <library id="htrace-core-3.1.0-incubating.jar"/>
              <library id="servlet-api-2.5.jar"/>
-             <library id="avro-1.7.5.jar"/>
+             <library id="avro-1.7.6.jar"/>
              <library id="jackson-mapper-asl-1.9.13.jar"/>
              <library id="jackson-core-asl-1.9.13.jar"/>
         </libraryNeededGroup>
@@ -403,7 +409,7 @@
              <library id="hadoop-yarn-api-emr450-latest"/>
              <library id="hadoop-yarn-client-emr450-latest"/>
              <library id="hadoop-yarn-common-emr450-latest"/>
-             <library id="avro-1.7.5.jar"/>
+             <library id="avro-1.7.6.jar"/>
              <library id="commons-configuration-1.6.jar"/>
              <library id="commons-lang-2.6.jar"/>
              <library id="commons-logging-1.1.3.jar"/>
@@ -455,7 +461,7 @@
              <library id="hadoop-yarn-api-emr450-latest"/>
              <library id="hadoop-yarn-client-emr450-latest"/>
              <library id="hadoop-yarn-common-emr450-latest"/>
-             <library id="avro-1.7.5.jar"/>
+             <library id="avro-1.7.6.jar"/>
              <library id="commons-configuration-1.6.jar"/>
              <library id="commons-lang-2.6.jar"/>
              <library id="commons-logging-1.1.3.jar"/>
@@ -604,7 +610,7 @@
              <library id="hadoop-yarn-api-emr450-latest"/>
              <library id="hadoop-yarn-client-emr450-latest"/>
              <library id="hadoop-yarn-common-emr450-latest"/>
-             <library id="avro-1.7.5.jar"/>
+             <library id="avro-1.7.6.jar"/>
              <library id="commons-configuration-1.6.jar"/>
              <library id="commons-httpclient-3.0.1.jar"/>
              <library id="gson-2.2.4.jar"/>
@@ -753,7 +759,7 @@
                 description="Spark Kafka Avro libraries for EMR 4.5.0 that are MRREQUIRED"
                 id="SPARK-KAFKA-AVRO-LIB-MRREQUIRED-EMR_4_5_0_LATEST"
                 name="SPARK-KAFKA-AVRO-LIB-MRREQUIRED-EMR_4_5_0_LATEST">
-            <library id="avro-1.7.5.jar"/>
+            <library id="avro-1.7.6.jar"/>
             <library id="jackson-mapper-asl-1.9.13.jar" />
             <library id="jackson-core-asl-1.9.13.jar" />
         </libraryNeededGroup>
@@ -797,37 +803,37 @@
       <!-- EMR 4.5.0 ClassLoaders -->
       <classloader
             index="HIVE2:AMAZON_EMR:EMR_4_5_0:STANDALONE"
-            libraries="antlr-runtime-3.4.jar;avro-1.7.5.jar;commons-cli-1.2.jar;commons-codec-1.4.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-httpclient-3.0.1.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;curator-client-2.6.0.jar;curator-framework-2.6.0.jar;datanucleus-api-jdo-3.2.6.jar;datanucleus-core-3.2.10.jar;datanucleus-rdbms-3.2.9.jar;derby-10.11.1.1.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-mapreduce-client-common-2.7.2-amzn-0.jar;hadoop-mapreduce-client-core-2.7.2-amzn-0.jar;hadoop-mapreduce-client-jobclient-2.7.2-amzn-0.jar;hadoop-yarn-api-2.7.2-amzn-0.jar;hadoop-yarn-client-2.7.2-amzn-0.jar;hadoop-yarn-common-2.7.2-amzn-0.jar;hive-exec-1.0.0-amzn-4.jar;hive-jdbc-1.0.0-amzn-4.jar;hive-metastore-1.0.0-amzn-4.jar;hive-serde-1.0.0-amzn-4.jar;hive-service-1.0.0-amzn-4.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jdo-api-3.0.1.jar;libfb303-0.9.0.jar;libthrift-0.9.0.jar;log4j-1.2.17.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;zookeeper-3.4.8.jar">
+            libraries="antlr-runtime-3.4.jar;avro-1.7.6.jar;commons-cli-1.2.jar;commons-codec-1.4.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-httpclient-3.0.1.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;curator-client-2.6.0.jar;curator-framework-2.6.0.jar;datanucleus-api-jdo-3.2.6.jar;datanucleus-core-3.2.10.jar;datanucleus-rdbms-3.2.9.jar;derby-10.11.1.1.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-mapreduce-client-common-2.7.2-amzn-0.jar;hadoop-mapreduce-client-core-2.7.2-amzn-0.jar;hadoop-mapreduce-client-jobclient-2.7.2-amzn-0.jar;hadoop-yarn-api-2.7.2-amzn-0.jar;hadoop-yarn-client-2.7.2-amzn-0.jar;hadoop-yarn-common-2.7.2-amzn-0.jar;hive-exec-1.0.0-amzn-4.jar;hive-jdbc-1.0.0-amzn-4.jar;hive-metastore-1.0.0-amzn-4.jar;hive-serde-1.0.0-amzn-4.jar;hive-service-1.0.0-amzn-4.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jdo-api-3.0.1.jar;libfb303-0.9.0.jar;libthrift-0.9.0.jar;log4j-1.2.17.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;zookeeper-3.4.8.jar">
       </classloader>
       <classloader
             index="MAP_REDUCE:AMAZON_EMR:EMR_4_5_0"
-            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-codec-1.4.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-mapreduce-client-common-2.7.2-amzn-0.jar;hadoop-mapreduce-client-core-2.7.2-amzn-0.jar;hadoop-mapreduce-client-jobclient-2.7.2-amzn-0.jar;hadoop-yarn-api-2.7.2-amzn-0.jar;hadoop-yarn-client-2.7.2-amzn-0.jar;hadoop-yarn-common-2.7.2-amzn-0.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jackson-core-asl-1.9.13.jar;jackson-jaxrs-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;jackson-xc-1.9.13.jar;jersey-client-1.9.jar;jersey-core-1.9.jar;jetty-util-6.1.26-emr.jar;jodd-core-3.5.2.jar;log4j-1.2.17.jar;parquet-hadoop-bundle-1.6.0.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;snappy-java-1.0.5.jar">
+            libraries="avro-1.7.6.jar;commons-cli-1.2.jar;commons-codec-1.4.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-mapreduce-client-common-2.7.2-amzn-0.jar;hadoop-mapreduce-client-core-2.7.2-amzn-0.jar;hadoop-mapreduce-client-jobclient-2.7.2-amzn-0.jar;hadoop-yarn-api-2.7.2-amzn-0.jar;hadoop-yarn-client-2.7.2-amzn-0.jar;hadoop-yarn-common-2.7.2-amzn-0.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jackson-core-asl-1.9.13.jar;jackson-jaxrs-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;jackson-xc-1.9.13.jar;jersey-client-1.9.jar;jersey-core-1.9.jar;jetty-util-6.1.26-emr.jar;jodd-core-3.5.2.jar;log4j-1.2.17.jar;parquet-hadoop-bundle-1.6.0.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;snappy-java-1.0.5.jar">
       </classloader>    
       <classloader
             index="HDFS:AMAZON_EMR:EMR_4_5_0"
-            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-lzo-0.4.19.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jackson-core-asl-1.9.13.jar;jackson-jaxrs-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;jackson-xc-1.9.13.jar;jersey-core-1.9.jar;jetty-util-6.1.26-emr.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar">
+            libraries="avro-1.7.6.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-lzo-0.4.19.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jackson-core-asl-1.9.13.jar;jackson-jaxrs-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;jackson-xc-1.9.13.jar;jersey-core-1.9.jar;jetty-util-6.1.26-emr.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar">
       </classloader>
       <classloader
             index="HDFS:AMAZON_EMR:EMR_4_5_0?USE_KRB"
-            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-lzo-0.4.19.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jackson-core-asl-1.9.13.jar;jackson-jaxrs-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;jackson-xc-1.9.13.jar;jersey-core-1.9.jar;jetty-util-6.1.26-emr.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;hadoop-conf-kerberos.jar">
+            libraries="avro-1.7.6.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-lzo-0.4.19.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jackson-core-asl-1.9.13.jar;jackson-jaxrs-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;jackson-xc-1.9.13.jar;jersey-core-1.9.jar;jetty-util-6.1.26-emr.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;hadoop-conf-kerberos.jar">
       </classloader>
       
       <!-- EMR 4.6.0 ClassLoaders -->
       <classloader
             index="HIVE2:AMAZON_EMR:EMR_4_6_0:STANDALONE"
-            libraries="antlr-runtime-3.4.jar;avro-1.7.5.jar;commons-cli-1.2.jar;commons-codec-1.4.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-httpclient-3.0.1.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;curator-client-2.6.0.jar;curator-framework-2.6.0.jar;datanucleus-api-jdo-3.2.6.jar;datanucleus-core-3.2.10.jar;datanucleus-rdbms-3.2.9.jar;derby-10.11.1.1.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-mapreduce-client-common-2.7.2-amzn-0.jar;hadoop-mapreduce-client-core-2.7.2-amzn-0.jar;hadoop-mapreduce-client-jobclient-2.7.2-amzn-0.jar;hadoop-yarn-api-2.7.2-amzn-0.jar;hadoop-yarn-client-2.7.2-amzn-0.jar;hadoop-yarn-common-2.7.2-amzn-0.jar;hive-exec-1.0.0-amzn-4.jar;hive-jdbc-1.0.0-amzn-4.jar;hive-metastore-1.0.0-amzn-4.jar;hive-serde-1.0.0-amzn-4.jar;hive-service-1.0.0-amzn-4.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jdo-api-3.0.1.jar;libfb303-0.9.0.jar;libthrift-0.9.0.jar;log4j-1.2.17.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;zookeeper-3.4.8.jar">
+            libraries="antlr-runtime-3.4.jar;avro-1.7.6.jar;commons-cli-1.2.jar;commons-codec-1.4.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-httpclient-3.0.1.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;curator-client-2.6.0.jar;curator-framework-2.6.0.jar;datanucleus-api-jdo-3.2.6.jar;datanucleus-core-3.2.10.jar;datanucleus-rdbms-3.2.9.jar;derby-10.11.1.1.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-mapreduce-client-common-2.7.2-amzn-0.jar;hadoop-mapreduce-client-core-2.7.2-amzn-0.jar;hadoop-mapreduce-client-jobclient-2.7.2-amzn-0.jar;hadoop-yarn-api-2.7.2-amzn-0.jar;hadoop-yarn-client-2.7.2-amzn-0.jar;hadoop-yarn-common-2.7.2-amzn-0.jar;hive-exec-1.0.0-amzn-4.jar;hive-jdbc-1.0.0-amzn-4.jar;hive-metastore-1.0.0-amzn-4.jar;hive-serde-1.0.0-amzn-4.jar;hive-service-1.0.0-amzn-4.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jdo-api-3.0.1.jar;libfb303-0.9.0.jar;libthrift-0.9.0.jar;log4j-1.2.17.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;zookeeper-3.4.8.jar">
       </classloader>
       <classloader
             index="MAP_REDUCE:AMAZON_EMR:EMR_4_6_0"
-            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-codec-1.4.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-mapreduce-client-common-2.7.2-amzn-0.jar;hadoop-mapreduce-client-core-2.7.2-amzn-0.jar;hadoop-mapreduce-client-jobclient-2.7.2-amzn-0.jar;hadoop-yarn-api-2.7.2-amzn-0.jar;hadoop-yarn-client-2.7.2-amzn-0.jar;hadoop-yarn-common-2.7.2-amzn-0.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jackson-core-asl-1.9.13.jar;jackson-jaxrs-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;jackson-xc-1.9.13.jar;jersey-client-1.9.jar;jersey-core-1.9.jar;jetty-util-6.1.26-emr.jar;jodd-core-3.5.2.jar;log4j-1.2.17.jar;parquet-hadoop-bundle-1.6.0.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;snappy-java-1.0.5.jar">
+            libraries="avro-1.7.6.jar;commons-cli-1.2.jar;commons-codec-1.4.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-mapreduce-client-common-2.7.2-amzn-0.jar;hadoop-mapreduce-client-core-2.7.2-amzn-0.jar;hadoop-mapreduce-client-jobclient-2.7.2-amzn-0.jar;hadoop-yarn-api-2.7.2-amzn-0.jar;hadoop-yarn-client-2.7.2-amzn-0.jar;hadoop-yarn-common-2.7.2-amzn-0.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jackson-core-asl-1.9.13.jar;jackson-jaxrs-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;jackson-xc-1.9.13.jar;jersey-client-1.9.jar;jersey-core-1.9.jar;jetty-util-6.1.26-emr.jar;jodd-core-3.5.2.jar;log4j-1.2.17.jar;parquet-hadoop-bundle-1.6.0.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;snappy-java-1.0.5.jar">
       </classloader>    
       <classloader
             index="HDFS:AMAZON_EMR:EMR_4_6_0"
-            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-lzo-0.4.19.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jackson-core-asl-1.9.13.jar;jackson-jaxrs-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;jackson-xc-1.9.13.jar;jersey-core-1.9.jar;jetty-util-6.1.26-emr.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar">
+            libraries="avro-1.7.6.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-lzo-0.4.19.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jackson-core-asl-1.9.13.jar;jackson-jaxrs-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;jackson-xc-1.9.13.jar;jersey-core-1.9.jar;jetty-util-6.1.26-emr.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar">
       </classloader>
       <classloader
             index="HDFS:AMAZON_EMR:EMR_4_6_0?USE_KRB"
-            libraries="avro-1.7.5.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-lzo-0.4.19.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jackson-core-asl-1.9.13.jar;jackson-jaxrs-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;jackson-xc-1.9.13.jar;jersey-core-1.9.jar;jetty-util-6.1.26-emr.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;hadoop-conf-kerberos.jar">
+            libraries="avro-1.7.6.jar;commons-cli-1.2.jar;commons-collections-3.2.2.jar;commons-configuration-1.6.jar;commons-io-2.4.jar;commons-lang-2.6.jar;commons-logging-1.1.3.jar;emr-metrics-client-2.1.0.jar;gson-2.2.4.jar;guava-11.0.2.jar;hadoop-auth-2.7.2-amzn-0.jar;hadoop-common-2.7.2-amzn-0.jar;hadoop-hdfs-2.7.2-amzn-0.jar;hadoop-lzo-0.4.19.jar;htrace-core-3.1.0-incubating.jar;httpclient-4.3.4.jar;httpcore-4.3.2.jar;jackson-core-asl-1.9.13.jar;jackson-jaxrs-1.9.13.jar;jackson-mapper-asl-1.9.13.jar;jackson-xc-1.9.13.jar;jersey-core-1.9.jar;jetty-util-6.1.26-emr.jar;log4j-1.2.17.jar;protobuf-java-2.5.0.jar;servlet-api-2.5.jar;slf4j-api-1.7.10.jar;slf4j-log4j12-1.7.10.jar;hadoop-conf-kerberos.jar">
       </classloader>      
       <classloader
             index="HBASE:AMAZON_EMR:EMR_4_6_0"


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

Redshift components are not working on EMR 4.5/4.6

**What is the new behavior?**

Redshift components are working on EMR 4.5/4.6
