### PR TITLE
fix(TUP-19529):Contextualize Custom Hadoop Connection - Unable to remove JobTrackerUri as field option.

### DIFF
--- a/main/plugins/org.talend.repository.hadoopcluster/src/org/talend/repository/hadoopcluster/ui/StandardHCInfoForm.java
+++ b/main/plugins/org.talend.repository.hadoopcluster/src/org/talend/repository/hadoopcluster/ui/StandardHCInfoForm.java
@@ -1583,7 +1583,7 @@ public class StandardHCInfoForm extends AbstractHadoopForm<HadoopClusterConnecti
     @Override
     protected void collectConParameters() {
         collectConFieldContextParameters(
-                isCurrentHadoopVersionSupportYarn() || (getConnection().isUseCustomConfs() && getConnection().isUseYarn()));
+                isCurrentHadoopVersionSupportYarn() || getConnection().isUseYarn());
         collectAuthFieldContextParameters(kerberosBtn.getSelection());
         collectKeyTabContextParameters(kerberosBtn.getSelection() && keytabBtn.getSelection());
         collectAuthMaprTFieldContextParameters(maprTBtn.getSelection());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
Contextualize Custom Hadoop Connection - Unable to remove JobTrackerUri as field option


**What is the new behavior?**
Can use the current Resource Manager in field as context if the custom use yarn mode


**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
