### PR TITLE
fix(TBD-6671): make Sqoop use driver class name when there is no built-in connection mananger

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tSqoopExport/tSqoopExport_javaapi.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tSqoopExport/tSqoopExport_javaapi.javajet
@@ -78,8 +78,12 @@
 	sqoopOptions_<%=cid%>.setExportDir(<%=exportDir%>);
 	sqoopOptions_<%=cid%>.setUsername(<%=username%>); // __USERNAME__
 	if((<%=driverClass%> != null) && !"".equals(<%=driverClass%>)) {
-		sqoopOptions_<%=cid%>.setDriverClassName(<%=driverClass%>);//driver class name
-	}
+    	com.cloudera.sqoop.metastore.JobData jobData_<%=cid%> = new com.cloudera.sqoop.metastore.JobData(sqoopOptions_<%=cid%>, null);
+    	org.apache.sqoop.manager.DefaultManagerFactory defaultManagerFactory_<%=cid%> = new org.apache.sqoop.manager.DefaultManagerFactory();
+    	if(null == defaultManagerFactory_<%=cid%>.accept(jobData_<%=cid%>)) {
+    		sqoopOptions_<%=cid%>.setDriverClassName(<%=driverClass%>);//driver class name
+    	}
+    }
 	
 	<%if(!passwordStoredInFile || !sqoopDistrib.doJavaAPISupportStorePasswordInFile()) {%>
 		<%

--- a/main/plugins/org.talend.designer.components.bigdata/components/tSqoopImport/tSqoopImport_javaapi.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tSqoopImport/tSqoopImport_javaapi.javajet
@@ -93,8 +93,12 @@
 	sqoopOptions_<%=cid%>.setConnectString(<%=connection%>); // __CONNECTION__
 	sqoopOptions_<%=cid%>.setUsername(<%=username%>); // __USERNAME__
 	if((<%=driverClass%> != null) && !"".equals(<%=driverClass%>)) {
-	sqoopOptions_<%=cid%>.setDriverClassName(<%=driverClass%>);//driver class name
-	}
+    	com.cloudera.sqoop.metastore.JobData jobData_<%=cid%> = new com.cloudera.sqoop.metastore.JobData(sqoopOptions_<%=cid%>, null);
+    	org.apache.sqoop.manager.DefaultManagerFactory defaultManagerFactory_<%=cid%> = new org.apache.sqoop.manager.DefaultManagerFactory();
+    	if(null == defaultManagerFactory_<%=cid%>.accept(jobData_<%=cid%>)) {
+    		sqoopOptions_<%=cid%>.setDriverClassName(<%=driverClass%>);//driver class name
+    	}
+    }
 	
    <%if(!passwordStoredInFile || !sqoopDistrib.doJavaAPISupportStorePasswordInFile()) {%>
 		<%

--- a/main/plugins/org.talend.designer.components.bigdata/components/tSqoopImportAllTables/tSqoopImportAllTables_javaapi.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tSqoopImportAllTables/tSqoopImportAllTables_javaapi.javajet
@@ -70,8 +70,12 @@
 	sqoopOptions_<%=cid%>.setConnectString(<%=connection%>); // __CONNECTION__
 	sqoopOptions_<%=cid%>.setUsername(<%=username%>); // __USERNAME__
 	if((<%=driverClass%> != null) && !"".equals(<%=driverClass%>)) {
-	sqoopOptions_<%=cid%>.setDriverClassName(<%=driverClass%>);//driver class name
-	}
+    	com.cloudera.sqoop.metastore.JobData jobData_<%=cid%> = new com.cloudera.sqoop.metastore.JobData(sqoopOptions_<%=cid%>, null);
+    	org.apache.sqoop.manager.DefaultManagerFactory defaultManagerFactory_<%=cid%> = new org.apache.sqoop.manager.DefaultManagerFactory();
+    	if(null == defaultManagerFactory_<%=cid%>.accept(jobData_<%=cid%>)) {
+    		sqoopOptions_<%=cid%>.setDriverClassName(<%=driverClass%>);//driver class name
+    	}
+    }
 	
    <%if(!passwordStoredInFile || !sqoopDistrib.doJavaAPISupportStorePasswordInFile()) {%>
 		<%

--- a/main/plugins/org.talend.designer.components.bigdata/components/tSqoopMerge/tSqoopMerge_javaapi.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tSqoopMerge/tSqoopMerge_javaapi.javajet
@@ -63,7 +63,11 @@
         needGenereateJarSqoopOptions_<%=cid%>.setConnectString(<%=connection%>); // __CONNECTION__
         needGenereateJarSqoopOptions_<%=cid%>.setUsername(<%=username%>);
         if((<%=driverClass%> != null) && !"".equals(<%=driverClass%>)) {
-        needGenereateJarSqoopOptions_<%=cid%>.setDriverClassName(<%=driverClass%>);//driver class name
+        	com.cloudera.sqoop.metastore.JobData jobData_<%=cid%> = new com.cloudera.sqoop.metastore.JobData(needGenereateJarSqoopOptions_<%=cid%>, null);
+        	org.apache.sqoop.manager.DefaultManagerFactory defaultManagerFactory_<%=cid%> = new org.apache.sqoop.manager.DefaultManagerFactory();
+        	if(null == defaultManagerFactory_<%=cid%>.accept(jobData_<%=cid%>)) {
+        		needGenereateJarSqoopOptions_<%=cid%>.setDriverClassName(<%=driverClass%>);//driver class name
+        	}
         }
         <%
         passwordFieldName = "__PASSWORD__";


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
