### PR TITLE
fix(TBD-7307): Replace talend-spark-assembly-1.6.0-cdh5.7.0 with cdh5.8.1

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.cdh570/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.cdh570/plugin.xml
@@ -228,10 +228,10 @@
         
         <!-- Spark libraries -->
         <libraryNeeded
-            context="plugin:org.talend.hadoop.distribution.cdh570"
-            id="spark-assembly-cdh5.7.0"
-            name="talend-spark-assembly-1.6.0-cdh5.7.0-hadoop2.6.0-with-hive-07122016.jar"
-            mvn_uri="mvn:org.talend.libraries/talend-spark-assembly-1.6.0-cdh5.7.0-hadoop2.6.0-with-hive-07122016/6.1.0">
+            context="plugin:org.talend.hadoop.distribution.cdh580"
+            id="spark-assembly-cdh5.8.1"
+            name="talend-spark-assembly-1.6.0-cdh5.8.1-hadoop2.6.0-cdh5.8.1-with-hive.jar"
+            mvn_uri="mvn:org.talend.libraries/talend-spark-assembly-1.6.0-cdh5.8.1-hadoop2.6.0-cdh5.8.1-with-hive/6.1.0">
         </libraryNeeded>
         
         <libraryNeeded
@@ -767,7 +767,7 @@
                 description="Spark libraries for CDH 5.5"
                 id="SPARK-LIB-CDH_5_7"
                 name="SPARK-LIB-CDH_5_7">
-             <library id="spark-assembly-cdh5.7.0" />
+             <library id="spark-assembly-cdh5.8.1" />
              <library id="jersey-server-1.14.jar" />
              <library id="jersey-servlet-1.14.jar" />
              <library id="jackson-databind-2.3.1.jar" />


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

Spark job hangs indefinitely when Core per executor more than 1.

**What is the new behavior?**

Spark job finishes completely.

**Other information**:
