### PR TITLE
fix(TBD-7961): Use Cloudera official jar for mllib-local on CDH 5.12

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.cdh5120/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.cdh5120/plugin.xml
@@ -804,7 +804,7 @@
 		<libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5120" id="spark-hive-exec_2.11-2.2.0.cloudera1.jar" name="spark-hive-exec_2.11-2.2.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-hive-exec_2.11-2.2.0.cloudera1/6.0.0"/>
 		<libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5120" id="spark-hive_2.11-2.2.0.cloudera1.jar" name="spark-hive_2.11-2.2.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-hive_2.11-2.2.0.cloudera1/6.0.0"/>
 		<libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5120" id="spark-launcher_2.11-2.2.0.cloudera1.jar" name="spark-launcher_2.11-2.2.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-launcher_2.11-2.2.0.cloudera1/6.0.0"/>
-		<libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5120" id="spark-mllib-local_2.11-2.2.0.cloudera1.jar" name="spark-mllib-local_2.11-2.2.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-mllib-local_2.11-2.2.0.cloudera1/6.0.0"/>
+		<libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5120" id="spark-mllib-local_2.11-2.2.0.cloudera1.jar" name="spark-mllib-local_2.11-2.2.0.cloudera1.jar" mvn_uri="mvn:org.apache.spark/spark-mllib-local_2.11/2.2.0.cloudera1"/>
 		<libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5120" id="spark-mllib_2.11-2.2.0.cloudera1.jar" name="spark-mllib_2.11-2.2.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-mllib_2.11-2.2.0.cloudera1/6.0.0"/>
 		<libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5120" id="spark-network-common_2.11-2.2.0.cloudera1.jar" name="spark-network-common_2.11-2.2.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-network-common_2.11-2.2.0.cloudera1/6.0.0"/>
 		<libraryNeeded context="plugin:org.talend.hadoop.distribution.cdh5120" id="spark-network-shuffle_2.11-2.2.0.cloudera1.jar" name="spark-network-shuffle_2.11-2.2.0.cloudera1.jar" mvn_uri="mvn:org.talend.libraries/spark-network-shuffle_2.11-2.2.0.cloudera1/6.0.0"/>
@@ -1257,8 +1257,8 @@
 			<library id="spark-hive-exec_2.11-2.2.0.cloudera1.jar"/>
 			<library id="spark-hive_2.11-2.2.0.cloudera1.jar"/>
 			<library id="spark-launcher_2.11-2.2.0.cloudera1.jar"/>
-			<library id="spark-mllib-local_2.11-2.2.0.cloudera1.jar"/>
 			<library id="spark-mllib_2.11-2.2.0.cloudera1.jar"/>
+			<library id="spark-mllib-local_2.11-2.2.0.cloudera1.jar"/>
 			<library id="spark-network-common_2.11-2.2.0.cloudera1.jar"/>
 			<library id="spark-network-shuffle_2.11-2.2.0.cloudera1.jar"/>
 			<library id="spark-repl_2.11-2.2.0.cloudera1.jar"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

Nexus jar for spark-mllib-local_2.11-2.2.0.cloudera1 and is conflicting with spark-mllib jar. Also it is different from official jar.

**What is the new behavior?**

Use official jar to replace the faulty jar which remove the conflict.
