### PR TITLE
fix(TBD-8075): Addition of slash support for AWS

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.cdh5x/src/org/talend/hadoop/distribution/cdh5x/CDH5xDistributionTemplate.java
+++ b/main/plugins/org.talend.hadoop.distribution.cdh5x/src/org/talend/hadoop/distribution/cdh5x/CDH5xDistributionTemplate.java
@@ -245,4 +245,9 @@ public class CDH5xDistributionTemplate extends AbstractDynamicCDHDistributionTem
     public boolean doSupportAvroDeflateProperties() {
         return true;
     }
+    
+    @Override
+    public boolean useOldAWSAPI() {
+        return false;
+    }
 }

--- a/main/plugins/org.talend.hadoop.distribution.databricks/src/main/java/org/talend/hadoop/distribution/databricks/DatabricksDistribution.java
+++ b/main/plugins/org.talend.hadoop.distribution.databricks/src/main/java/org/talend/hadoop/distribution/databricks/DatabricksDistribution.java
@@ -225,5 +225,10 @@ public class DatabricksDistribution extends AbstractDistribution implements Spar
     public boolean doSupportS3() {
         return true;
     }
+    
+    @Override
+    public boolean useOldAWSAPI() {
+        return false;
+    }
 
 }

--- a/main/plugins/org.talend.hadoop.distribution.qubole/src/main/java/org/talend/hadoop/distribution/qubole/QuboleDistribution.java
+++ b/main/plugins/org.talend.hadoop.distribution.qubole/src/main/java/org/talend/hadoop/distribution/qubole/QuboleDistribution.java
@@ -316,4 +316,9 @@ public class QuboleDistribution extends AbstractDistribution implements SparkBat
     public boolean doSupportBackpressure() {
         return false;
     }
+    
+    @Override
+    public boolean useOldAWSAPI() {
+        return false;
+    }
 }


### PR DESCRIPTION
Wrong AWS API used for some distributions

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

Databricks, Qubole, CDH dynamic distributions does not support slashes in AWS S3 URIs and fallback to anonymous authentication if so.

**What is the new behavior?**

All these distributions have support enabled for slashes.
