### PR TITLE
fix(TBD-8145): Use newer s3a key properties for EMR 5.15 (#946)

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.emr5150/src/main/java/org/talend/hadoop/distribution/emr5150/EMR5150Distribution.java
+++ b/main/plugins/org.talend.hadoop.distribution.emr5150/src/main/java/org/talend/hadoop/distribution/emr5150/EMR5150Distribution.java
@@ -510,4 +510,9 @@ public class EMR5150Distribution extends AbstractDistribution implements HBaseCo
     public short orderingWeight() {
         return 10;
     }
+
+    @Override
+    public boolean useS3AProperties() {
+        return true;
+    }
 }


### PR DESCRIPTION
#946 