### PR TITLE
fix(TUP-15692)Check fail for Second Neo4j 2.2.x connection when I

### DIFF
--- a/main/plugins/org.talend.repository.nosql/src/messages.properties
+++ b/main/plugins/org.talend.repository.nosql/src/messages.properties
@@ -154,4 +154,5 @@ noSQLRepositoryTranslator.NEO4J_2_3_X=Neo4J 2.3.X
 noSQLRepositoryTranslator.NEO4J_3_2_X=Neo4J 3.2.X
 
 noSQLRepositoryTranslator.NEO4J=Neo4j
+noSQLConnectionTest.cancelCheckConnection=Check connection canceled.
 

--- a/main/plugins/org.talend.repository.nosql/src/org/talend/repository/nosql/db/util/mongodb/MongoDBConnectionUtil.java
+++ b/main/plugins/org.talend.repository.nosql/src/org/talend/repository/nosql/db/util/mongodb/MongoDBConnectionUtil.java
@@ -39,7 +39,6 @@ import org.talend.repository.nosql.reflection.NoSQLReflection;
 import org.talend.utils.json.JSONArray;
 import org.talend.utils.json.JSONException;
 import org.talend.utils.json.JSONObject;
-import org.talend.utils.security.CryptoHelper;
 
 public class MongoDBConnectionUtil {
 
@@ -48,6 +47,10 @@ public class MongoDBConnectionUtil {
     public static synchronized boolean checkConnection(NoSQLConnection connection) throws NoSQLServerException {
         boolean canConnect = true;
         try {
+            // if cancel to interrupt check connection, throw exception
+            if (Thread.currentThread().interrupted()) {
+                throw new InterruptedException(); // $NON-NLS-1$
+            }
             Object db = getDB(connection);
             if (db == null) {
                 List<String> databaseNames = getDatabaseNames(connection);
@@ -66,10 +69,18 @@ public class MongoDBConnectionUtil {
             if (db == null) {
                 throw new NoSQLServerException(Messages.getString("MongoDBConnectionUtil.NoAvailableDatabase")); //$NON-NLS-1$
             }
+            // if cancel to interrupt check connection, throw exception
+            if (Thread.currentThread().interrupted()) {
+                throw new InterruptedException(); // $NON-NLS-1$
+            }
             NoSQLReflection.invokeMethod(db, "getStats"); //$NON-NLS-1$
         } catch (Exception e) {
             canConnect = false;
-            throw new NoSQLServerException(Messages.getString("MongoDBConnectionUtil.CanotConnectDatabase"), e); //$NON-NLS-1$
+            if (e instanceof InterruptedException) {
+                throw new NoSQLServerException(Messages.getString("noSQLConnectionTest.cancelCheckConnection"), e); //$NON-NLS-1$
+            } else {
+                throw new NoSQLServerException(Messages.getString("MongoDBConnectionUtil.CanotConnectDatabase"), e); //$NON-NLS-1$
+            }
         }
 
         return canConnect;

--- a/main/plugins/org.talend.repository.nosql/src/org/talend/repository/nosql/db/util/mongodb/MongoDBConnectionUtil.java
+++ b/main/plugins/org.talend.repository.nosql/src/org/talend/repository/nosql/db/util/mongodb/MongoDBConnectionUtil.java
@@ -49,7 +49,7 @@ public class MongoDBConnectionUtil {
         try {
             // if cancel to interrupt check connection, throw exception
             if (Thread.currentThread().interrupted()) {
-                throw new InterruptedException(); // $NON-NLS-1$
+                throw new InterruptedException();
             }
             Object db = getDB(connection);
             if (db == null) {
@@ -57,6 +57,10 @@ public class MongoDBConnectionUtil {
                 if (databaseNames != null && databaseNames.size() > 0) {
                     for (String databaseName : databaseNames) {
                         if (StringUtils.isNotEmpty(databaseName)) {
+                            // if cancel to interrupt check connection, throw exception
+                            if (Thread.currentThread().interrupted()) {
+                                throw new InterruptedException();
+                            }
                             db = getDB(connection, databaseName);
                             if (db != null) {
                                 break;
@@ -71,7 +75,7 @@ public class MongoDBConnectionUtil {
             }
             // if cancel to interrupt check connection, throw exception
             if (Thread.currentThread().interrupted()) {
-                throw new InterruptedException(); // $NON-NLS-1$
+                throw new InterruptedException();
             }
             NoSQLReflection.invokeMethod(db, "getStats"); //$NON-NLS-1$
         } catch (Exception e) {

--- a/main/plugins/org.talend.repository.nosql/src/org/talend/repository/nosql/db/util/neo4j/Neo4jConnectionUtil.java
+++ b/main/plugins/org.talend.repository.nosql/src/org/talend/repository/nosql/db/util/neo4j/Neo4jConnectionUtil.java
@@ -32,7 +32,6 @@ import org.talend.repository.nosql.exceptions.NoSQLServerException;
 import org.talend.repository.nosql.factory.NoSQLClassLoaderFactory;
 import org.talend.repository.nosql.i18n.Messages;
 import org.talend.repository.nosql.reflection.NoSQLReflection;
-import org.talend.utils.security.CryptoHelper;
 
 /**
  *
@@ -50,6 +49,7 @@ public class Neo4jConnectionUtil {
     public static synchronized boolean checkConnection(NoSQLConnection connection) throws NoSQLServerException {
         boolean canConnect = true;
         final ClassLoader classLoader = NoSQLClassLoaderFactory.getClassLoader(connection);
+        Thread.currentThread().setContextClassLoader(classLoader);
         Object dbConnection = null;
         try {
             boolean isRemote = Boolean.valueOf(connection.getAttributes().get(INeo4jAttributes.REMOTE_SERVER));

--- a/main/plugins/org.talend.repository.nosql/src/org/talend/repository/nosql/db/util/neo4j/Neo4jConnectionUtil.java
+++ b/main/plugins/org.talend.repository.nosql/src/org/talend/repository/nosql/db/util/neo4j/Neo4jConnectionUtil.java
@@ -49,6 +49,7 @@ public class Neo4jConnectionUtil {
     public static synchronized boolean checkConnection(NoSQLConnection connection) throws NoSQLServerException {
         boolean canConnect = true;
         final ClassLoader classLoader = NoSQLClassLoaderFactory.getClassLoader(connection);
+        ClassLoader currCL = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(classLoader);
         Object dbConnection = null;
         try {
@@ -112,6 +113,7 @@ public class Neo4jConnectionUtil {
             if (dbConnection != null) {
                 shutdownNeo4JDb(dbConnection);
             }
+            Thread.currentThread().setContextClassLoader(currCL);
         }
 
         return canConnect;

--- a/main/plugins/org.talend.repository.nosql/src/org/talend/repository/nosql/ui/common/AbstractNoSQLConnForm.java
+++ b/main/plugins/org.talend.repository.nosql/src/org/talend/repository/nosql/ui/common/AbstractNoSQLConnForm.java
@@ -12,11 +12,16 @@
 // ============================================================================
 package org.talend.repository.nosql.ui.common;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.dialogs.ProgressMonitorDialog;
+import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
@@ -37,6 +42,7 @@ import org.talend.metadata.managment.ui.utils.ExtendedNodeConnectionContextUtils
 import org.talend.repository.nosql.RepositoryNoSQLPlugin;
 import org.talend.repository.nosql.constants.INoSQLConstants;
 import org.talend.repository.nosql.context.NoSQLConnectionContextManager;
+import org.talend.repository.nosql.exceptions.NoSQLServerException;
 import org.talend.repository.nosql.factory.NoSQLRepositoryFactory;
 import org.talend.repository.nosql.i18n.Messages;
 import org.talend.repository.nosql.metadata.IMetadataProvider;
@@ -136,9 +142,30 @@ public abstract class AbstractNoSQLConnForm extends AbstractNoSQLForm {
                 public void widgetSelected(SelectionEvent e) {
                     try {
                         if (getConnection() != null) {
-                            IMetadataProvider metadataProvider = NoSQLRepositoryFactory.getInstance().getMetadataProvider(
-                                    getConnection().getDbType());
-                            if (metadataProvider != null && metadataProvider.checkConnection(getConnection())) {
+                            final AtomicBoolean checkedResult = new AtomicBoolean(false);
+                            IRunnableWithProgress runnableWithProgress = new IRunnableWithProgress() {
+
+                                @Override
+                                public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+                                    IMetadataProvider metadataProvider = NoSQLRepositoryFactory.getInstance().getMetadataProvider(
+                                            getConnection().getDbType());
+                                    if (metadataProvider != null) {
+                                        try {
+                                            checkedResult.set(metadataProvider.checkConnection(getConnection()));
+                                        } catch (NoSQLServerException e) {
+                                            new ErrorDialogWidthDetailArea(getShell(), RepositoryNoSQLPlugin.PLUGIN_ID, Messages
+                                                    .getString("AbstractNoSQLConnForm.checkFailed"), //$NON-NLS-1$
+                                                    ExceptionUtils.getFullStackTrace(e));
+                                            ExceptionHandler.process(e);
+                                        }
+                                    }
+                                }
+
+                            };
+                            ProgressMonitorDialog dialog = new ProgressMonitorDialog(getShell());
+                            dialog.run(true, true, runnableWithProgress);
+                            
+                            if (checkedResult.get()) {
                                 MessageDialog.openInformation(
                                         getShell(),
                                         Messages.getString("AbstractNoSQLConnForm.checkConn"), Messages.getString("AbstractNoSQLConnForm.checkSuccessful")); //$NON-NLS-1$ //$NON-NLS-2$

--- a/test/plugins/org.talend.repository.nosql.test/src/org/talend/repository/nosql/db/util/neo4j/Neo4jConnectionUtilTest.java
+++ b/test/plugins/org.talend.repository.nosql.test/src/org/talend/repository/nosql/db/util/neo4j/Neo4jConnectionUtilTest.java
@@ -93,7 +93,7 @@ public class Neo4jConnectionUtilTest {
 
         attributes.put(INeo4jAttributes.DATABASE_PATH, tmpFolder.getCanonicalPath());
 
-        attributes.put(INeo4jAttributes.DB_VERSION, INeo4jConstants.NEO4J_2_3_X);
+        attributes.put(INeo4jAttributes.DB_VERSION, INeo4jConstants.NEO4J_2_1_X);
 
         localConnection.setDbType("NEO4J");
         // TUP-15696:"Check Service" for Neo4j does not work after first check.

--- a/test/plugins/org.talend.repository.nosql.test/src/org/talend/repository/nosql/db/util/neo4j/Neo4jConnectionUtilTest.java
+++ b/test/plugins/org.talend.repository.nosql.test/src/org/talend/repository/nosql/db/util/neo4j/Neo4jConnectionUtilTest.java
@@ -14,8 +14,12 @@ package org.talend.repository.nosql.db.util.neo4j;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.eclipse.emf.common.util.EMap;
 import org.junit.After;
@@ -28,6 +32,7 @@ import org.talend.repository.model.nosql.NosqlFactory;
 import org.talend.repository.nosql.constants.INoSQLCommonAttributes;
 import org.talend.repository.nosql.db.common.neo4j.INeo4jAttributes;
 import org.talend.repository.nosql.db.common.neo4j.INeo4jConstants;
+import org.talend.repository.nosql.exceptions.NoSQLServerException;
 import org.talend.utils.io.FilesUtils;
 
 /**
@@ -93,13 +98,41 @@ public class Neo4jConnectionUtilTest {
 
         attributes.put(INeo4jAttributes.DATABASE_PATH, tmpFolder.getCanonicalPath());
 
-        attributes.put(INeo4jAttributes.DB_VERSION, INeo4jConstants.NEO4J_2_1_X);
+        attributes.put(INeo4jAttributes.DB_VERSION, INeo4jConstants.NEO4J_2_3_X);
 
         localConnection.setDbType("NEO4J");
         // TUP-15696:"Check Service" for Neo4j does not work after first check.
         // so check twice here
-        assertTrue(Neo4jConnectionUtil.checkConnection(localConnection));
-        assertTrue(Neo4jConnectionUtil.checkConnection(localConnection));
+
+        ExecutorService threadExecutor = null;
+        try {
+            threadExecutor = Executors.newSingleThreadExecutor();
+            Future future = threadExecutor.submit(new Runnable() {
+
+                public void run() {
+                    try {
+                        Neo4jConnectionUtil.checkConnection(localConnection);
+                        assertTrue(Neo4jConnectionUtil.checkConnection(localConnection));
+                    } catch (NoSQLServerException e) {
+                        fail(e.getMessage());
+                    }
+                }
+            });
+
+            while (true) {
+                if (future.get() == null) {
+                    break;
+                }
+                Thread.sleep(1000);
+            }
+        } catch (Exception exception) {
+            fail(exception.getMessage());
+        } finally {
+            if (threadExecutor != null) {
+                threadExecutor.shutdown();
+            }
+        }
+
     }
     
     @Test

--- a/test/plugins/org.talend.repository.nosql.test/src/org/talend/repository/nosql/db/util/neo4j/Neo4jMetadataProviderTest.java
+++ b/test/plugins/org.talend.repository.nosql.test/src/org/talend/repository/nosql/db/util/neo4j/Neo4jMetadataProviderTest.java
@@ -1,10 +1,14 @@
 package org.talend.repository.nosql.db.util.neo4j;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.eclipse.emf.common.util.EMap;
 import org.junit.After;
@@ -47,20 +51,47 @@ public class Neo4jMetadataProviderTest {
 
         attributes.put(INeo4jAttributes.DATABASE_PATH, tmpFolder.getCanonicalPath());
 
-        attributes.put(INeo4jAttributes.DB_VERSION, INeo4jConstants.NEO4J_2_1_X);
+        attributes.put(INeo4jAttributes.DB_VERSION, INeo4jConstants.NEO4J_2_3_X);
         localConnection.setDbType("NEO4J");
-        Neo4jConnectionUtil.checkConnection(localConnection);
-        List<MetadataColumn> metadataColumns = new ArrayList<MetadataColumn>();
-        String cypher = "create (n:Test {first_name : 'Peppa', last_name : 'Pig'})\r\nreturn n;";
-        IMetadataProvider metadataProvider = NoSQLRepositoryFactory.getInstance()
-                .getMetadataProvider(localConnection.getDbType());
-        metadataColumns = metadataProvider.extractColumns(localConnection, cypher);
 
-        String lastName = metadataColumns.get(0).getName();
-        assertEquals("last_name", lastName);
-        String firstName = metadataColumns.get(1).getName();
-        assertEquals("first_name", firstName);
+        ExecutorService threadExecutor = null;
+        try {
+            threadExecutor = Executors.newSingleThreadExecutor();
+            Future future = threadExecutor.submit(new Runnable() {
 
+                public void run() {
+                    try {
+                        Neo4jConnectionUtil.checkConnection(localConnection);
+                        List<MetadataColumn> metadataColumns = new ArrayList<MetadataColumn>();
+                        String cypher = "create (n:Test {first_name : 'Peppa', last_name : 'Pig'})\r\nreturn n;";
+                        IMetadataProvider metadataProvider = NoSQLRepositoryFactory.getInstance()
+                                .getMetadataProvider(localConnection.getDbType());
+                        metadataColumns = metadataProvider.extractColumns(localConnection, cypher);
+
+                        String lastName = metadataColumns.get(0).getName();
+                        assertEquals("last_name", lastName);
+                        String firstName = metadataColumns.get(1).getName();
+                        assertEquals("first_name", firstName);
+                    } catch (Exception e) {
+                        fail(e.getMessage());
+                    }
+                }
+            });
+
+            while (true) {
+                if (future.get() == null) {
+                    break;
+                }
+                Thread.sleep(1000);
+            }
+        } catch (Exception exception) {
+            fail(exception.getMessage());
+        } finally {
+            if (threadExecutor != null) {
+                threadExecutor.shutdown();
+                threadExecutor = null;
+            }
+        }
     }
 
 }

--- a/test/plugins/org.talend.repository.nosql.test/src/org/talend/repository/nosql/db/util/neo4j/Neo4jMetadataProviderTest.java
+++ b/test/plugins/org.talend.repository.nosql.test/src/org/talend/repository/nosql/db/util/neo4j/Neo4jMetadataProviderTest.java
@@ -47,7 +47,7 @@ public class Neo4jMetadataProviderTest {
 
         attributes.put(INeo4jAttributes.DATABASE_PATH, tmpFolder.getCanonicalPath());
 
-        attributes.put(INeo4jAttributes.DB_VERSION, INeo4jConstants.NEO4J_2_3_X);
+        attributes.put(INeo4jAttributes.DB_VERSION, INeo4jConstants.NEO4J_2_1_X);
         localConnection.setDbType("NEO4J");
         Neo4jConnectionUtil.checkConnection(localConnection);
         List<MetadataColumn> metadataColumns = new ArrayList<MetadataColumn>();


### PR DESCRIPTION
already checked Neo4j 2.1.x connection
https://jira.talendforge.org/browse/TUP-15692

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
