### PR TITLE
fix(TDI-41553): Fix compile error when old mongo version used

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tMongoDBOutput/tMongoDBOutput_main_below_3_5.javajet
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tMongoDBOutput/tMongoDBOutput_main_below_3_5.javajet
@@ -88,11 +88,15 @@
                         }
 		            }
   				}
-  				// Get the BasicDBObject
+				// Get the BasicDBObject
 				%>
 				com.mongodb.BasicDBObject updateObj_<%=cid%> = updateObjectUtil_<%=cid%>.getObject();
-				<%
-
+<%
+				if (dbversion.equals("MONGODB_2_5_X")) {
+%>
+				try {
+<%
+				}
 				// INSERT operation
 				if ("INSERT".equalsIgnoreCase(dataAction)) {
 					// Bulk Writes
@@ -252,33 +256,33 @@
 				<%
 				}
 
-				// Die on Error 
-				// Used only with MONGODB 2.5
-				// 2.5 doesn't support BulkWrites => No BulkWrites Die and Error
-                if (dbversion.equals("MONGODB_2_5_X")) {
-                    %>
-    				if(resultMessage_<%=cid%>!=null && resultMessage_<%=cid%>.getError()!=null){
-    					<%
-    					if(dieOnError){
-    					%>
-    						throw new Exception(resultMessage_<%=cid%>.getError());
-    					<%
-    					}else{
-    						if(isLog4jEnabled){
-    						%>
-    							log.error("<%=cid%> - " + resultMessage_<%=cid%>.getError());
-    						<%
-    						}
-    						%>
-    						System.err.println(resultMessage_<%=cid%>.getError());
-    					<%
-    					}
-    					%>
-    				}
-    				<%
-                }
-
-    			%>
+			// Die on Error
+			// Used only with MONGODB 2.5
+			// 2.5 doesn't support BulkWrites => No BulkWrites Die and Error
+			if (dbversion.equals("MONGODB_2_5_X")) {
+%>
+				} catch (Exception e) {
+<%
+						if(dieOnError){
+%>
+							throw e;
+<%
+						} else {
+							if(isLog4jEnabled) {
+%>
+								log.error("<%=cid%> - " + e.getMessage());
+<%
+							} else {
+%>
+								System.err.println("<%=cid%> - " + e.getMessage());
+<%
+							}
+						}
+%>
+				}
+<%
+			}
+%>
 				nb_line_<%=cid %> ++;
 				<%
 


### PR DESCRIPTION
Backport to 6.5

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
