### PR TITLE
fix(TDI-42689) : Uprade js-lib to 2.4.2-talend

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tCosmosDBWriteConf/tCosmosDBWriteConf_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tCosmosDBWriteConf/tCosmosDBWriteConf_java.xml
@@ -300,7 +300,7 @@
             <IMPORT NAME="commons_lang" MODULE="commons-lang-2.6.jar" MVN="mvn:commons-lang/commons-lang/2.6"  UrlPath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-lang-2.6.jar" REQUIRED="true" />
             <IMPORT NAME="commons_logging" MODULE="commons-logging-1.1.1.jar" MVN="mvn:org.talend.libraries/commons-logging-1.1.1/6.0.0"  UrlPath="platform:/base/plugins/org.apache.commons.logging_1.1.1.v201101211721.jar" REQUIRED="true" />
             <IMPORT NAME="ezmorph" MODULE="ezmorph-1.0.6.jar" MVN="mvn:org.talend.libraries/ezmorph-1.0.6/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.jackson/lib/ezmorph-1.0.6.jar" REQUIRED="true" />
-            <IMPORT NAME="json-lib" MODULE="json-lib-2.4.1-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.1-talend" REQUIRED="true" />
+            <IMPORT NAME="json-lib" MODULE="json-lib-2.4.2-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.2-talend" REQUIRED="true" />
         </IMPORTS>
 	</CODEGENERATION>
 	<RETURNS>

--- a/main/plugins/org.talend.designer.components.bigdata/components/tMongoDBWriteConf/tMongoDBWriteConf_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tMongoDBWriteConf/tMongoDBWriteConf_java.xml
@@ -331,7 +331,7 @@
             <IMPORT NAME="commons_lang" MODULE="commons-lang-2.6.jar" MVN="mvn:commons-lang/commons-lang/2.6"  UrlPath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-lang-2.6.jar" REQUIRED="true" />
             <IMPORT NAME="commons_logging" MODULE="commons-logging-1.1.1.jar" MVN="mvn:org.talend.libraries/commons-logging-1.1.1/6.0.0"  UrlPath="platform:/base/plugins/org.apache.commons.logging_1.1.1.v201101211721.jar" REQUIRED="true" />
             <IMPORT NAME="ezmorph" MODULE="ezmorph-1.0.6.jar" MVN="mvn:org.talend.libraries/ezmorph-1.0.6/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.jackson/lib/ezmorph-1.0.6.jar" REQUIRED="true" />
-            <IMPORT NAME="json-lib" MODULE="json-lib-2.4.1-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.1-talend" REQUIRED="true" />
+            <IMPORT NAME="json-lib" MODULE="json-lib-2.4.2-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.2-talend" REQUIRED="true" />
         </IMPORTS>
 	</CODEGENERATION>
 	<RETURNS>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-42689

**What is the new behavior?**
BigDecimal is used instead of float & double to avoid lose of decimal precision.
Upgrade json-lib from 2.4.1-talend to -2.4.2-talend to have the fix.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


