### PR TITLE
fix(TDI-42834): upgrade commons-compress library to latest version

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tNeo4jBatchOutput/tNeo4jBatchOutput_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tNeo4jBatchOutput/tNeo4jBatchOutput_java.xml
@@ -133,7 +133,7 @@
 			<IMPORT NAME="bcpkix-jdk15on-1.53" MODULE="bcpkix-jdk15on-1.53.jar"  MVN="mvn:org.talend.libraries/bcpkix-jdk15on-1.53/6.0.0"  REQUIRED="true"/>
 			<IMPORT NAME="bcprov-jdk15on-1.53" MODULE="bcprov-jdk15on-1.53.jar"  MVN="mvn:org.talend.libraries/bcprov-jdk15on-1.53/6.0.0"  REQUIRED="true"/>
 			<IMPORT NAME="caffeine-2.3.3" MODULE="caffeine-2.3.3.jar"  MVN="mvn:org.talend.libraries/caffeine-2.3.3/6.0.0"  REQUIRED="true"/>
-			<IMPORT NAME="commons-compress-1.12" MODULE="commons-compress-1.12.jar"  MVN="mvn:org.talend.libraries/commons-compress-1.12/6.0.0"  REQUIRED="true"/>
+			<IMPORT NAME="commons-compress-1.19" MODULE="commons-compress-1.19.jar"  MVN="mvn:org.apache.commons/commons-compress/1.19"  REQUIRED="true"/>
 			<IMPORT NAME="commons-lang3-3.8.1" MODULE="commons-lang3-3.8.1.jar"  MVN="mvn:org.apache.commons/commons-lang3/3.8.1"  REQUIRED="true"/>
 			<IMPORT NAME="concurrentlinkedhashmap-lru-1.4.2" MODULE="concurrentlinkedhashmap-lru-1.4.2.jar"  MVN="mvn:org.talend.libraries/concurrentlinkedhashmap-lru-1.4.2/6.0.0"  REQUIRED="true"/>
 			<IMPORT NAME="lucene-analyzers-common-5.5.0" MODULE="lucene-analyzers-common-5.5.0.jar"  MVN="mvn:org.talend.libraries/lucene-analyzers-common-5.5.0/6.0.0"  REQUIRED="true"/>

--- a/main/plugins/org.talend.designer.components.bigdata/components/tNeo4jBatchOutputRelationship/tNeo4jBatchOutputRelationship_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tNeo4jBatchOutputRelationship/tNeo4jBatchOutputRelationship_java.xml
@@ -150,7 +150,7 @@
 			<IMPORT NAME="bcpkix-jdk15on-1.53" MODULE="bcpkix-jdk15on-1.53.jar"  MVN="mvn:org.talend.libraries/bcpkix-jdk15on-1.53/6.0.0"  REQUIRED="true"/>
 			<IMPORT NAME="bcprov-jdk15on-1.53" MODULE="bcprov-jdk15on-1.53.jar"  MVN="mvn:org.talend.libraries/bcprov-jdk15on-1.53/6.0.0"  REQUIRED="true"/>
 			<IMPORT NAME="caffeine-2.3.3" MODULE="caffeine-2.3.3.jar"  MVN="mvn:org.talend.libraries/caffeine-2.3.3/6.0.0"  REQUIRED="true"/>
-			<IMPORT NAME="commons-compress-1.12" MODULE="commons-compress-1.12.jar"  MVN="mvn:org.talend.libraries/commons-compress-1.12/6.0.0"  REQUIRED="true"/>
+			<IMPORT NAME="commons-compress-1.19" MODULE="commons-compress-1.19.jar"  MVN="mvn:org.apache.commons/commons-compress/1.19"  REQUIRED="true"/>
 			<IMPORT NAME="commons-lang3-3.8.1" MODULE="commons-lang3-3.8.1.jar"  MVN="mvn:org.apache.commons/commons-lang3/3.8.1"  REQUIRED="true"/>
 			<IMPORT NAME="concurrentlinkedhashmap-lru-1.4.2" MODULE="concurrentlinkedhashmap-lru-1.4.2.jar"  MVN="mvn:org.talend.libraries/concurrentlinkedhashmap-lru-1.4.2/6.0.0"  REQUIRED="true"/>
 			<IMPORT NAME="lucene-analyzers-common-5.5.0" MODULE="lucene-analyzers-common-5.5.0.jar"  MVN="mvn:org.talend.libraries/lucene-analyzers-common-5.5.0/6.0.0"  REQUIRED="true"/>

--- a/main/plugins/org.talend.designer.components.bigdata/components/tNeo4jBatchSchema/tNeo4jBatchSchema_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tNeo4jBatchSchema/tNeo4jBatchSchema_java.xml
@@ -122,7 +122,7 @@
 			<IMPORT NAME="bcpkix-jdk15on-1.53" MODULE="bcpkix-jdk15on-1.53.jar"  MVN="mvn:org.talend.libraries/bcpkix-jdk15on-1.53/6.0.0"  REQUIRED="true"/>
 			<IMPORT NAME="bcprov-jdk15on-1.53" MODULE="bcprov-jdk15on-1.53.jar"  MVN="mvn:org.talend.libraries/bcprov-jdk15on-1.53/6.0.0"  REQUIRED="true"/>
 			<IMPORT NAME="caffeine-2.3.3" MODULE="caffeine-2.3.3.jar"  MVN="mvn:org.talend.libraries/caffeine-2.3.3/6.0.0"  REQUIRED="true"/>
-			<IMPORT NAME="commons-compress-1.12" MODULE="commons-compress-1.12.jar"  MVN="mvn:org.talend.libraries/commons-compress-1.12/6.0.0"  REQUIRED="true"/>
+			<IMPORT NAME="commons-compress-1.19" MODULE="commons-compress-1.19.jar"  MVN="mvn:org.apache.commons/commons-compress/1.19"  REQUIRED="true"/>
 			<IMPORT NAME="commons-lang3-3.8.1" MODULE="commons-lang3-3.8.1.jar"  MVN="mvn:org.apache.commons/commons-lang3/3.8.1"  REQUIRED="true"/>
 			<IMPORT NAME="concurrentlinkedhashmap-lru-1.4.2" MODULE="concurrentlinkedhashmap-lru-1.4.2.jar"  MVN="mvn:org.talend.libraries/concurrentlinkedhashmap-lru-1.4.2/6.0.0"  REQUIRED="true"/>
 			<IMPORT NAME="lucene-analyzers-common-5.5.0" MODULE="lucene-analyzers-common-5.5.0.jar"  MVN="mvn:org.talend.libraries/lucene-analyzers-common-5.5.0/6.0.0"  REQUIRED="true"/>

--- a/main/plugins/org.talend.designer.components.bigdata/components/tNeo4jConnection/tNeo4jConnection_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tNeo4jConnection/tNeo4jConnection_java.xml
@@ -499,7 +499,7 @@
 			<IMPORT NAME="bcpkix-jdk15on-1.53" MODULE="bcpkix-jdk15on-1.53.jar"  MVN="mvn:org.talend.libraries/bcpkix-jdk15on-1.53/6.0.0"  REQUIRED_IF="(DB_VERSION=='NEO4J_3_2_X') AND (REMOTE_SERVER == 'false')"/>
 			<IMPORT NAME="bcprov-jdk15on-1.53" MODULE="bcprov-jdk15on-1.53.jar"  MVN="mvn:org.talend.libraries/bcprov-jdk15on-1.53/6.0.0"  REQUIRED_IF="(DB_VERSION=='NEO4J_3_2_X') AND (REMOTE_SERVER == 'false')"/>
 			<IMPORT NAME="caffeine-2.3.3" MODULE="caffeine-2.3.3.jar"  MVN="mvn:org.talend.libraries/caffeine-2.3.3/6.0.0"  REQUIRED_IF="(DB_VERSION=='NEO4J_3_2_X') AND (REMOTE_SERVER == 'false')"/>
-			<IMPORT NAME="commons-compress-1.12" MODULE="commons-compress-1.12.jar"  MVN="mvn:org.talend.libraries/commons-compress-1.12/6.0.0"  REQUIRED_IF="(DB_VERSION=='NEO4J_3_2_X') AND (REMOTE_SERVER == 'false')"/>
+			<IMPORT NAME="commons-compress-1.19" MODULE="commons-compress-1.19.jar"  MVN="mvn:org.apache.commons/commons-compress/1.19"  REQUIRED_IF="(DB_VERSION=='NEO4J_3_2_X') AND (REMOTE_SERVER == 'false')"/>
 			<IMPORT NAME="commons-lang3-3.8.1" MODULE="commons-lang3-3.8.1.jar"  MVN="mvn:org.apache.commons/commons-lang3/3.8.1"  REQUIRED_IF="(DB_VERSION=='NEO4J_3_2_X') AND (REMOTE_SERVER == 'false')"/>
 			<IMPORT NAME="concurrentlinkedhashmap-lru-1.4.2" MODULE="concurrentlinkedhashmap-lru-1.4.2.jar"  MVN="mvn:org.talend.libraries/concurrentlinkedhashmap-lru-1.4.2/6.0.0"  REQUIRED_IF="(DB_VERSION=='NEO4J_3_2_X') AND (REMOTE_SERVER == 'false')"/>
 			<IMPORT NAME="lucene-analyzers-common-5.5.0" MODULE="lucene-analyzers-common-5.5.0.jar"  MVN="mvn:org.talend.libraries/lucene-analyzers-common-5.5.0/6.0.0"  REQUIRED_IF="(DB_VERSION=='NEO4J_3_2_X') AND (REMOTE_SERVER == 'false')"/>

--- a/main/plugins/org.talend.designer.components.bigdata/components/tNeo4jImportTool/tNeo4jImportTool_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tNeo4jImportTool/tNeo4jImportTool_java.xml
@@ -121,7 +121,7 @@
 			<IMPORT NAME="bcpkix-jdk15on-1.53" MODULE="bcpkix-jdk15on-1.53.jar"  MVN="mvn:org.talend.libraries/bcpkix-jdk15on-1.53/6.0.0"  REQUIRED="true"/>
 			<IMPORT NAME="bcprov-jdk15on-1.53" MODULE="bcprov-jdk15on-1.53.jar"  MVN="mvn:org.talend.libraries/bcprov-jdk15on-1.53/6.0.0"  REQUIRED="true"/>
 			<IMPORT NAME="caffeine-2.3.3" MODULE="caffeine-2.3.3.jar"  MVN="mvn:org.talend.libraries/caffeine-2.3.3/6.0.0"  REQUIRED="true"/>
-			<IMPORT NAME="commons-compress-1.12" MODULE="commons-compress-1.12.jar"  MVN="mvn:org.talend.libraries/commons-compress-1.12/6.0.0"  REQUIRED="true"/>
+			<IMPORT NAME="commons-compress-1.19" MODULE="commons-compress-1.19.jar"  MVN="mvn:org.apache.commons/commons-compress/1.19"  REQUIRED="true"/>
 			<IMPORT NAME="commons-lang3-3.8.1" MODULE="commons-lang3-3.8.1.jar"  MVN="mvn:org.apache.commons/commons-lang3/3.8.1"  REQUIRED="true"/>
 			<IMPORT NAME="concurrentlinkedhashmap-lru-1.4.2" MODULE="concurrentlinkedhashmap-lru-1.4.2.jar"  MVN="mvn:org.talend.libraries/concurrentlinkedhashmap-lru-1.4.2/6.0.0"  REQUIRED="true"/>
 			<IMPORT NAME="lucene-analyzers-common-5.5.0" MODULE="lucene-analyzers-common-5.5.0.jar"  MVN="mvn:org.talend.libraries/lucene-analyzers-common-5.5.0/6.0.0"  REQUIRED="true"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [x] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
Commons-compress library from Apache has multiple different version in components.


**What is the new behavior?**
Align common-compress library version to newest available - 1.19 (https://commons.apache.org/proper/commons-compress/)


**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
