### PR TITLE
fix(TBD-9421): add missing okkio dependency

### DIFF
--- a/main/plugins/org.talend.repository.hadoopcluster.configurator/pom.xml
+++ b/main/plugins/org.talend.repository.hadoopcluster.configurator/pom.xml
@@ -140,9 +140,8 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${project.basedir}/lib</outputDirectory>
-
                             <includeGroupIds>
-                                org.apache.geronimo.specs,javax.annotation,com.cloudera.api.swagger,io.swagger,com.google,com.squareup.okhttp,joda-time,com.sun.xml.bind,com.fasterxml.jackson,org.jetbrains,org.hamcrest
+                                org.apache.geronimo.specs,javax.annotation,com.cloudera.api.swagger,io.swagger,com.google,com.squareup.okhttp,com.squareup.okio,joda-time,com.sun.xml.bind,com.fasterxml.jackson,org.jetbrains,org.hamcrest
                             </includeGroupIds>
 
                         </configuration>


### PR DESCRIPTION
add missing okkio dependency

**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

package com.squareup.okio is a transitive dependency of cloudera manager API.
It miss in the filter for copy-dependencies phase.


**What is the new behavior?**

added missing groupId com.squareup.okio
remove non needed org.hamcrest groupId as it is a test scope dependencies


**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
