### PR TITLE
chore(TBD-9561): add sanity check on commit message

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,5 +36,14 @@ pipeline {
                 }
             }
         }
+        stage('Commit check'){
+            steps {
+                container('python2') {
+                    sh '''
+                        python ./tools/commit-check.py
+                        '''
+                }
+            }
+        }
     }
 }

--- a/tools/commit-check.py
+++ b/tools/commit-check.py
@@ -1,6 +1,21 @@
 import os
+import re
 
-semantic_commits_regex = "(?:chore|docs|feat|fix|refactor|style|test)[\(\[](?:TBD|TDI|TUP|DEVOPS)-(?:\d{4})[)\]]:.*"
+team_tickets = "TBD|TDI|TUP|DEVOPS"
+semantics = "chore|docs|feat|fix|refactor|style|test"
+
+tbd_commit_regex = "(?:%s)[\(\[\:](?:%s)-(?:\d{4})([)\]]:|:).**" % (semantics, team_tickets)
+
+# feat(TBD-9011): tata
+# chore[TBD-9011]: titi
+# refactor:TBD-9011: toto
+
+COLOR_RED = '\033[1;31m'
+END_COLOR = '\033[1;m'
+
+
+def red(text):
+    return '%s%s%s' % (COLOR_RED, str(text), END_COLOR)
 
 
 def check_commit_message():
@@ -20,6 +35,13 @@ def check_commit_message():
         print(os.environ['TAG_TIMESTAMP'])
         print(os.environ['TAG_UNIXTIME'])
         print(os.environ['TAG_UNIXTIME'])
+    result = re.search(tbd_commit_regex, os.environ['CHANGE_TITLE'])
+    if result is None:
+        print("ERROR : the message does not follow convention. %s" % red(os.environ['CHANGE_TITLE']))
+        print("")
+    (start, end) = result.span()
+    if start != 0:
+        print("ERROR : unexpected prefix %s" % red(result[0:start]))
 
 
 if __name__ == '__main__':

--- a/tools/commit-check.py
+++ b/tools/commit-check.py
@@ -1,3 +1,4 @@
+# coding=utf8
 import os
 import re
 
@@ -5,11 +6,15 @@ team_tickets = "TBD|TDI|TUP|DEVOPS"
 semantic_prefixs = "chore|docs|feat|fix|refactor|style|test"
 
 tbd_commit_regex = "(%s)[\(\[\:]((?:%s)-(?:\d{3,7}))(?:[)\]]:|:)(.*)" % (semantic_prefixs, team_tickets)
-# this regex will extract some information based on the accepted convention
-# feat(TBD-901): tata       ==> group1: feat,     group2: TBD-901,   group3: tata
-# chore[TBD-9011]: titi     ==> group1: chore,    group2: TBD-9011,  group3: titi
-# refactor:TBD-99011: toto  ==> group1: refactor, group2: TBD-99011, group3: toto
+# this regex will extract some information based on the accepted convention:
+# group1 : semantic, group2: ticket ID, group3: message
+# Some samples:
+# feat(TBD-901): msg1       ==> group1: feat,     group2: TBD-901,   group3: msg1
+# chore[TBD-9011]: msg2     ==> group1: chore,    group2: TBD-9011,  group3: msg2
+# refactor:TBD-99011: msg3  ==> group1: refactor, group2: TBD-99011, group3: msg3
 
+COLOR_GREEN = '\033[1;32m'
+COLOR_YELLOW = '\033[1;33m'
 COLOR_RED = '\033[1;31m'
 END_COLOR = '\033[1;m'
 
@@ -18,15 +23,23 @@ def red(text):
     return '%s%s%s' % (COLOR_RED, str(text), END_COLOR)
 
 
+def yellow(text):
+    return '%s%s%s' % (COLOR_YELLOW, str(text), END_COLOR)
+
+
+def green(text):
+    return '%s%s%s' % (COLOR_GREEN, str(text), END_COLOR)
+
+
 def check_commit_message():
     print('CHANGE_TITLE=%s' % os.environ['CHANGE_TITLE'])
     print('CHANGE_URL=%s' % os.environ['CHANGE_URL'])
-    print('CHANGE_AUTHOR=%s' % os.environ['CHANGE_AUTHOR'])
-    print('CHANGE_AUTHOR_DISPLAY_NAME=%s' % os.environ['CHANGE_AUTHOR_DISPLAY_NAME'])
-    print('CHANGE_AUTHOR_EMAIL=%s' % os.environ['CHANGE_AUTHOR_EMAIL'])
-    print('CHANGE_BRANCH=%s' % os.environ['CHANGE_BRANCH'])
-    print('CHANGE_TARGET=%s' % os.environ['CHANGE_TARGET'])
-    print('CHANGE_ID=%s' % os.environ['CHANGE_ID'])
+    # print('CHANGE_AUTHOR=%s' % os.environ['CHANGE_AUTHOR'])
+    # print('CHANGE_AUTHOR_DISPLAY_NAME=%s' % os.environ['CHANGE_AUTHOR_DISPLAY_NAME'])
+    # print('CHANGE_AUTHOR_EMAIL=%s' % os.environ['CHANGE_AUTHOR_EMAIL'])
+    # print('CHANGE_BRANCH=%s' % os.environ['CHANGE_BRANCH'])
+    # print('CHANGE_TARGET=%s' % os.environ['CHANGE_TARGET'])
+    # print('CHANGE_ID=%s' % os.environ['CHANGE_ID'])
     print('BRANCH_NAME=%s' % os.environ['BRANCH_NAME'])
     if 'CHANGE_FORK' in os.environ:
         print("CHANGE_FORK=%s" % os.environ['CHANGE_FORK'])
@@ -37,11 +50,23 @@ def check_commit_message():
         print(os.environ['TAG_UNIXTIME'])
     result = re.search(tbd_commit_regex, os.environ['CHANGE_TITLE'])
     if result is None:
-        print("ERROR : the message does not follow convention. %s" % red(os.environ['CHANGE_TITLE']))
         print("")
-    (start, end) = result.span()
-    if start != 0:
-        print("ERROR : unexpected prefix %s" % red(result[0:start]))
+        print("%s: the message does not follow convention. '%s'" % (red('ERROR'), red(os.environ['CHANGE_TITLE'])))
+        exit(-1)
+    else:
+        (start, end) = result.span()
+        if start != 0:
+            print("%s: unexpected prefix '%s'" % (red('ERROR'), red(result.string[0:start])))
+        else:
+            semantic = result.group(1)
+            ticket_id = result.group(2)
+            message = result.group(3)
+            print("%s: commit message is valid for %s:\n\tsemantic : %s\n\tticket   : %s\n\tmessage  : %s"
+                  % (green('INFO'),
+                     yellow(os.environ['BRANCH_NAME']),
+                     green(semantic),
+                     green(ticket_id),
+                     green(message.strip())))
 
 
 if __name__ == '__main__':

--- a/tools/commit-check.py
+++ b/tools/commit-check.py
@@ -2,13 +2,13 @@ import os
 import re
 
 team_tickets = "TBD|TDI|TUP|DEVOPS"
-semantics = "chore|docs|feat|fix|refactor|style|test"
+semantic_prefixs = "chore|docs|feat|fix|refactor|style|test"
 
-tbd_commit_regex = "(?:%s)[\(\[\:](?:%s)-(?:\d{4})([)\]]:|:).**" % (semantics, team_tickets)
-
-# feat(TBD-9011): tata
-# chore[TBD-9011]: titi
-# refactor:TBD-9011: toto
+tbd_commit_regex = "(%s)[\(\[\:]((?:%s)-(?:\d{3,7}))(?:[)\]]:|:)(.*)" % (semantic_prefixs, team_tickets)
+# this regex will extract some information based on the accepted convention
+# feat(TBD-901): tata       ==> group1: feat,     group2: TBD-901,   group3: tata
+# chore[TBD-9011]: titi     ==> group1: chore,    group2: TBD-9011,  group3: titi
+# refactor:TBD-99011: toto  ==> group1: refactor, group2: TBD-99011, group3: toto
 
 COLOR_RED = '\033[1;31m'
 END_COLOR = '\033[1;m'

--- a/tools/commit-check.py
+++ b/tools/commit-check.py
@@ -57,7 +57,7 @@ def check_commit_message():
     #     print(os.environ['TAG_UNIXTIME'])
     result = re.search(tbd_commit_regex, os.environ['CHANGE_TITLE'])
     if result is None:
-        print("")
+        print()
         print("%s: the message does not follow convention. '%s'" % (red('ERROR'), red(os.environ['CHANGE_TITLE'])))
         print()
         print('check tickets prefix is in [%s]' % yellow(team_tickets))

--- a/tools/commit-check.py
+++ b/tools/commit-check.py
@@ -1,0 +1,26 @@
+import os
+
+semantic_commits_regex = "(?:chore|docs|feat|fix|refactor|style|test)[\(\[](?:TBD|TDI|TUP|DEVOPS)-(?:\d{4})[)\]]:.*"
+
+
+def check_commit_message():
+    print('CHANGE_TITLE=%s' % os.environ['CHANGE_TITLE'])
+    print('CHANGE_URL=%s' % os.environ['CHANGE_URL'])
+    print('CHANGE_AUTHOR=%s' % os.environ['CHANGE_AUTHOR'])
+    print('CHANGE_AUTHOR_DISPLAY_NAME=%s' % os.environ['CHANGE_AUTHOR_DISPLAY_NAME'])
+    print('CHANGE_AUTHOR_EMAIL=%s' % os.environ['CHANGE_AUTHOR_EMAIL'])
+    print('CHANGE_BRANCH=%s' % os.environ['CHANGE_BRANCH'])
+    print('CHANGE_TARGET=%s' % os.environ['CHANGE_TARGET'])
+    print('CHANGE_ID=%s' % os.environ['CHANGE_ID'])
+    print('BRANCH_NAME=%s' % os.environ['BRANCH_NAME'])
+    if 'CHANGE_FORK' in os.environ:
+        print("CHANGE_FORK=%s" % os.environ['CHANGE_FORK'])
+    if 'TAG_NAME' in os.environ:
+        print(os.environ['TAG_NAME'])
+        print(os.environ['TAG_TIMESTAMP'])
+        print(os.environ['TAG_UNIXTIME'])
+        print(os.environ['TAG_UNIXTIME'])
+
+
+if __name__ == '__main__':
+    check_commit_message()

--- a/tools/commit-check.py
+++ b/tools/commit-check.py
@@ -3,15 +3,13 @@ import os
 import re
 
 team_tickets = "TBD|TDI|TUP|DEVOPS"
-semantic_prefixs = "chore|docs|feat|fix|refactor|style|test"
+semantic_prefixes = "chore|docs|feat|fix|refactor|style|test"
 
-tbd_commit_regex = "(%s)[\(\[\:]((?:%s)-(?:\d{3,7}))(?:[)\]]:|:)(.*)" % (semantic_prefixs, team_tickets)
+tbd_commit_regex = "(%s)[\(\[\:]((?:%s)-(?:\d{3,7}))(?:[)\]]:|:)(.*)" % (semantic_prefixes, team_tickets)
 # this regex will extract some information based on the accepted convention:
 # group1 : semantic, group2: ticket ID, group3: message
-# Some samples:
-# feat(TBD-901): msg1       ==> group1: feat,     group2: TBD-901,   group3: msg1
-# chore[TBD-9011]: msg2     ==> group1: chore,    group2: TBD-9011,  group3: msg2
-# refactor:TBD-99011: msg3  ==> group1: refactor, group2: TBD-99011, group3: msg3
+# Some samples are listed in case of errors
+
 
 COLOR_GREEN = '\033[1;32m'
 COLOR_YELLOW = '\033[1;33m'
@@ -31,27 +29,43 @@ def green(text):
     return '%s%s%s' % (COLOR_GREEN, str(text), END_COLOR)
 
 
+def print_sample(commit, feat, ticket, message):
+    print('%-40s ==> semantic: %-20s, ticket: %-23s, description: %s' % (
+        green(commit),
+        green(feat),
+        green(ticket),
+        green(message)
+    ))
+
+
 def check_commit_message():
-    print('CHANGE_TITLE=%s' % os.environ['CHANGE_TITLE'])
-    print('CHANGE_URL=%s' % os.environ['CHANGE_URL'])
+    # print('CHANGE_TITLE=%s' % os.environ['CHANGE_TITLE'])
+    # print('CHANGE_URL=%s' % os.environ['CHANGE_URL'])
     # print('CHANGE_AUTHOR=%s' % os.environ['CHANGE_AUTHOR'])
     # print('CHANGE_AUTHOR_DISPLAY_NAME=%s' % os.environ['CHANGE_AUTHOR_DISPLAY_NAME'])
     # print('CHANGE_AUTHOR_EMAIL=%s' % os.environ['CHANGE_AUTHOR_EMAIL'])
     # print('CHANGE_BRANCH=%s' % os.environ['CHANGE_BRANCH'])
     # print('CHANGE_TARGET=%s' % os.environ['CHANGE_TARGET'])
     # print('CHANGE_ID=%s' % os.environ['CHANGE_ID'])
-    print('BRANCH_NAME=%s' % os.environ['BRANCH_NAME'])
-    if 'CHANGE_FORK' in os.environ:
-        print("CHANGE_FORK=%s" % os.environ['CHANGE_FORK'])
-    if 'TAG_NAME' in os.environ:
-        print(os.environ['TAG_NAME'])
-        print(os.environ['TAG_TIMESTAMP'])
-        print(os.environ['TAG_UNIXTIME'])
-        print(os.environ['TAG_UNIXTIME'])
+    # print('BRANCH_NAME=%s' % os.environ['BRANCH_NAME'])
+    # if 'CHANGE_FORK' in os.environ:
+    #     print("CHANGE_FORK=%s" % os.environ['CHANGE_FORK'])
+    # if 'TAG_NAME' in os.environ:
+    #     print(os.environ['TAG_NAME'])
+    #     print(os.environ['TAG_TIMESTAMP'])
+    #     print(os.environ['TAG_UNIXTIME'])
+    #     print(os.environ['TAG_UNIXTIME'])
     result = re.search(tbd_commit_regex, os.environ['CHANGE_TITLE'])
     if result is None:
         print("")
         print("%s: the message does not follow convention. '%s'" % (red('ERROR'), red(os.environ['CHANGE_TITLE'])))
+        print()
+        print('check tickets prefix is in [%s]' % yellow(team_tickets))
+        print('check semantic prefix is in [%s]' % yellow(semantic_prefixes))
+        print('\nsome samples:')
+        print_sample('feat(TBD-007): msg1', 'feat', 'TBD-007', 'msg1')
+        print_sample('chore[TUP-1984]: msg2', 'chore', 'TUP-1984', 'msg2')
+        print_sample('refactor:TDI-199999: msg3', 'refactor', 'TDI-199999', 'msg3')
         exit(-1)
     else:
         (start, end) = result.span()

--- a/tools/sanity-check.py
+++ b/tools/sanity-check.py
@@ -141,7 +141,8 @@ def sanity_check(directories):
 def check_commit_message():
     print(os.environ['CHANGE_TITLE'])
     print(os.environ['CHANGE_URL'])
-    print(os.environ['CHANGE_FORK'])
+    if 'CHANGE_FORK' in os.environ:
+        print("CHANGE_FORK=%s" % os.environ['CHANGE_FORK'])
     print(os.environ['CHANGE_AUTHOR'])
     print(os.environ['CHANGE_AUTHOR_DISPLAY_NAME'])
     print(os.environ['CHANGE_AUTHOR_EMAIL'])

--- a/tools/sanity-check.py
+++ b/tools/sanity-check.py
@@ -138,6 +138,23 @@ def sanity_check(directories):
     return errors
 
 
+def check_commit_message():
+    print(os.environ['CHANGE_TITLE'])
+    print(os.environ['CHANGE_URL'])
+    print(os.environ['CHANGE_FORK'])
+    print(os.environ['CHANGE_AUTHOR'])
+    print(os.environ['CHANGE_AUTHOR_DISPLAY_NAME'])
+    print(os.environ['CHANGE_AUTHOR_EMAIL'])
+    print(os.environ['CHANGE_BRANCH'])
+    print(os.environ['CHANGE_TARGET'])
+    print(os.environ['CHANGE_ID'])
+    print(os.environ['BRANCH_NAME'])
+    print(os.environ['TAG_NAME'])
+    print(os.environ['TAG_TIMESTAMP'])
+    print(os.environ['TAG_UNIXTIME'])
+    print(os.environ['TAG_UNIXTIME'])
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='check consistency between directory structure, pom.xml and build.properties')
@@ -146,6 +163,7 @@ if __name__ == '__main__':
                         default='main/plugins:test/plugins')
     args = parser.parse_args()
     plugin_directories = args.directories.split(':')
+    check_commit_message()
     nb_errors = sanity_check(plugin_directories)
     if nb_errors != 0:
         print("%sProject is not correctly configured (%s %s found).%s" % (

--- a/tools/sanity-check.py
+++ b/tools/sanity-check.py
@@ -138,25 +138,6 @@ def sanity_check(directories):
     return errors
 
 
-def check_commit_message():
-    print(os.environ['CHANGE_TITLE'])
-    print(os.environ['CHANGE_URL'])
-    print('CHANGE_AUTHOR=%s' % os.environ['CHANGE_AUTHOR'])
-    print('CHANGE_AUTHOR_DISPLAY_NAME=%s' % os.environ['CHANGE_AUTHOR_DISPLAY_NAME'])
-    print('CHANGE_AUTHOR_EMAIL=%s' % os.environ['CHANGE_AUTHOR_EMAIL'])
-    print('CHANGE_BRANCH=%s' % os.environ['CHANGE_BRANCH'])
-    print('CHANGE_TARGET=%s' % os.environ['CHANGE_TARGET'])
-    print('CHANGE_ID=%s' % os.environ['CHANGE_ID'])
-    print('BRANCH_NAME=%s' % os.environ['BRANCH_NAME'])
-    if 'CHANGE_FORK' in os.environ:
-        print("CHANGE_FORK=%s" % os.environ['CHANGE_FORK'])
-    if 'TAG_NAME' in os.environ:
-        print(os.environ['TAG_NAME'])
-        print(os.environ['TAG_TIMESTAMP'])
-        print(os.environ['TAG_UNIXTIME'])
-        print(os.environ['TAG_UNIXTIME'])
-
-
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='check consistency between directory structure, pom.xml and build.properties')
@@ -165,7 +146,6 @@ if __name__ == '__main__':
                         default='main/plugins:test/plugins')
     args = parser.parse_args()
     plugin_directories = args.directories.split(':')
-    check_commit_message()
     nb_errors = sanity_check(plugin_directories)
     if nb_errors != 0:
         print("%sProject is not correctly configured (%s %s found).%s" % (

--- a/tools/sanity-check.py
+++ b/tools/sanity-check.py
@@ -141,19 +141,20 @@ def sanity_check(directories):
 def check_commit_message():
     print(os.environ['CHANGE_TITLE'])
     print(os.environ['CHANGE_URL'])
+    print('CHANGE_AUTHOR=%s' % os.environ['CHANGE_AUTHOR'])
+    print('CHANGE_AUTHOR_DISPLAY_NAME=%s' % os.environ['CHANGE_AUTHOR_DISPLAY_NAME'])
+    print('CHANGE_AUTHOR_EMAIL=%s' % os.environ['CHANGE_AUTHOR_EMAIL'])
+    print('CHANGE_BRANCH=%s' % os.environ['CHANGE_BRANCH'])
+    print('CHANGE_TARGET=%s' % os.environ['CHANGE_TARGET'])
+    print('CHANGE_ID=%s' % os.environ['CHANGE_ID'])
+    print('BRANCH_NAME=%s' % os.environ['BRANCH_NAME'])
     if 'CHANGE_FORK' in os.environ:
         print("CHANGE_FORK=%s" % os.environ['CHANGE_FORK'])
-    print(os.environ['CHANGE_AUTHOR'])
-    print(os.environ['CHANGE_AUTHOR_DISPLAY_NAME'])
-    print(os.environ['CHANGE_AUTHOR_EMAIL'])
-    print(os.environ['CHANGE_BRANCH'])
-    print(os.environ['CHANGE_TARGET'])
-    print(os.environ['CHANGE_ID'])
-    print(os.environ['BRANCH_NAME'])
-    print(os.environ['TAG_NAME'])
-    print(os.environ['TAG_TIMESTAMP'])
-    print(os.environ['TAG_UNIXTIME'])
-    print(os.environ['TAG_UNIXTIME'])
+    if 'TAG_NAME' in os.environ:
+        print(os.environ['TAG_NAME'])
+        print(os.environ['TAG_TIMESTAMP'])
+        print(os.environ['TAG_UNIXTIME'])
+        print(os.environ['TAG_UNIXTIME'])
 
 
 if __name__ == '__main__':

--- a/tools/sanity-check.py
+++ b/tools/sanity-check.py
@@ -1,3 +1,4 @@
+# coding=utf8
 import argparse
 import javaproperties
 import os


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

Description

There is a consensus in Talend about what a commit message format.
ON TBD repositories, there is no tools to ensure this format. 

As a consequence, this format is not followed everytime and history
is a little bit hard to read/understand.

**What is the new behavior?**

Add a simple script that check the format.

**Ticket is** TBD-9561

**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
