### PR TITLE
fix(TBD-9793): Failed to retrieve hbase schema for CDH5.13 and HDP2.6

### DIFF
--- a/main/plugins/org.talend.repository.hbaseprovider/src/org/talend/repository/hbaseprovider/provider/HBaseMetadataProvider.java
+++ b/main/plugins/org.talend.repository.hbaseprovider/src/org/talend/repository/hbaseprovider/provider/HBaseMetadataProvider.java
@@ -13,6 +13,7 @@
 package org.talend.repository.hbaseprovider.provider;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -242,7 +243,13 @@ public class HBaseMetadataProvider implements IDBMetadataProvider {
      */
     @SuppressWarnings("unchecked")
     protected List<Object> getTableDescriptors(Object /*org.apache.hadoop.hbase.client.Admin*/ hAdmin) throws Exception {
-        return (List<Object>) ReflectionUtils.invokeMethod(hAdmin, "listTableDescriptors", EMPTY_ARRAY); //$NON-NLS-1$
+        try {
+            return (List<Object>) ReflectionUtils.invokeMethod(hAdmin, "listTableDescriptors", EMPTY_ARRAY); //$NON-NLS-1$
+        } catch (NoSuchMethodException nsme) {
+            //try old one
+            Object[] tables = (Object[]) ReflectionUtils.invokeMethod(hAdmin, "listTables", EMPTY_ARRAY); //$NON-NLS-1$
+            return Arrays.asList(tables);
+        }
     }
 
     /**
@@ -253,7 +260,12 @@ public class HBaseMetadataProvider implements IDBMetadataProvider {
      * @throws Exception
      */
     protected Object /*org.apache.hadoop.hbase.client.TableDescriptor*/ getTableDescriptor(Object hTable) throws Exception {
-        return ReflectionUtils.invokeMethod(hTable, "getDescriptor", EMPTY_ARRAY); //$NON-NLS-1$
+        try {
+            return ReflectionUtils.invokeMethod(hTable, "getDescriptor", EMPTY_ARRAY); //$NON-NLS-1$
+        } catch (NoSuchMethodException nsme) {
+            //try old one
+            return ReflectionUtils.invokeMethod(hTable, "getTableDescriptor", EMPTY_ARRAY); //$NON-NLS-1$
+        }
     }
 
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
TBD-9793
We can not retrieve anymore tables and columns from the schema retreiver.
This is due to some API in CDH 5.13 that is not the standard one (still got some old methods names).

**What is the new behavior?**

Try the standard one, in case of NoSuchMethodError, try the old one. This allow the retreiver to be able to work with CDH 5.13

**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
