### PR TITLE
fix(TBD-9807): missing jar for Dataproc 1.4

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.dataproc14/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.dataproc14/plugin.xml
@@ -8,7 +8,7 @@
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="talend-bigdata-launcher"
             name="talend-bigdata-launcher-platform-1.4.1.jar"
-            mvn_uri="mvn:org.talend.bigdata.libs/talend-bigdata-launcher-platform-1.4.1/6.0.0">
+            mvn_uri="mvn:org.talend.libraries/talend-bigdata-launcher-platform-1.4.2/6.0.0">
         </libraryNeeded>
         <libraryNeeded
 		    context="plugin:org.talend.hadoop.distribution.dataproc14"


### PR DESCRIPTION
Fix the maven uri and the version of a jar for Google Dataproc 1.4

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
