### PR TITLE
fix(TDI-43610): jsonutil bump version to 2.4.5-talend

### DIFF
--- a/main/plugins/org.talend.designer.components.bigdata/components/tCosmosDBWriteConf/tCosmosDBWriteConf_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tCosmosDBWriteConf/tCosmosDBWriteConf_java.xml
@@ -300,7 +300,7 @@
             <IMPORT NAME="commons_lang" MODULE="commons-lang-2.6.jar" MVN="mvn:commons-lang/commons-lang/2.6"  UrlPath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-lang-2.6.jar" REQUIRED="true" />
             <IMPORT NAME="commons_logging" MODULE="commons-logging-1.1.1.jar" MVN="mvn:org.talend.libraries/commons-logging-1.1.1/6.0.0"  UrlPath="platform:/base/plugins/org.apache.commons.logging_1.1.1.v201101211721.jar" REQUIRED="true" />
             <IMPORT NAME="ezmorph" MODULE="ezmorph-1.0.6.jar" MVN="mvn:org.talend.libraries/ezmorph-1.0.6/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.jackson/lib/ezmorph-1.0.6.jar" REQUIRED="true" />
-            <IMPORT NAME="json-lib" MODULE="json-lib-2.4.3-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.3-talend" REQUIRED="true" />
+            <IMPORT NAME="json-lib" MODULE="json-lib-2.4.5-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.5-talend" REQUIRED="true" />
         </IMPORTS>
 	</CODEGENERATION>
 	<RETURNS>

--- a/main/plugins/org.talend.designer.components.bigdata/components/tMongoDBWriteConf/tMongoDBWriteConf_java.xml
+++ b/main/plugins/org.talend.designer.components.bigdata/components/tMongoDBWriteConf/tMongoDBWriteConf_java.xml
@@ -331,7 +331,7 @@
             <IMPORT NAME="commons_lang" MODULE="commons-lang-2.6.jar" MVN="mvn:commons-lang/commons-lang/2.6"  UrlPath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-lang-2.6.jar" REQUIRED="true" />
             <IMPORT NAME="commons_logging" MODULE="commons-logging-1.1.1.jar" MVN="mvn:org.talend.libraries/commons-logging-1.1.1/6.0.0"  UrlPath="platform:/base/plugins/org.apache.commons.logging_1.1.1.v201101211721.jar" REQUIRED="true" />
             <IMPORT NAME="ezmorph" MODULE="ezmorph-1.0.6.jar" MVN="mvn:org.talend.libraries/ezmorph-1.0.6/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.jackson/lib/ezmorph-1.0.6.jar" REQUIRED="true" />
-            <IMPORT NAME="json-lib" MODULE="json-lib-2.4.3-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.3-talend" REQUIRED="true" />
+            <IMPORT NAME="json-lib" MODULE="json-lib-2.4.5-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.5-talend" REQUIRED="true" />
         </IMPORTS>
 	</CODEGENERATION>
 	<RETURNS>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-43610

**What is the new behavior?**
A decimal value in a json with non-significant 0, keep at least one non-significant 0 to keep the double type "10.0000" -> "10.0"

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
