### PR TITLE
chore[TBD-9558]: remove classloader junit of HDInsight3.4

### DIFF
--- a/test/plugins/org.talend.hadoop.distribution.hdinsight340.test/src/org/talend/hadoop/distribution/hdinsight340/test/HDInsight34ClassLoaderTest.java
+++ b/test/plugins/org.talend.hadoop.distribution.hdinsight340.test/src/org/talend/hadoop/distribution/hdinsight340/test/HDInsight34ClassLoaderTest.java
@@ -30,12 +30,6 @@ public class HDInsight34ClassLoaderTest extends AbstractTest4ClassLoaderProvider
     }
 
     @Test
-    public void testMapReduce() {
-        String libsStr = "azure-storage-1.2.0.jar;commons-cli-1.2.jar;commons-codec-1.9.jar;commons-collections-3.2.1.jar;commons-configuration-1.6.jar;commons-lang-2.6.jar;commons-logging-1.2.jar;cxf-rt-bindings-xml-3.3.4.jar;cxf-core-3.3.4.jar;cxf-rt-frontend-jaxrs-3.3.4.jar;cxf-rt-transports-http-3.3.4.jar;guava-12.0.1.jar;hadoop-auth-2.7.1.2.4.1.0-327.jar;hadoop-common-2.7.1.2.4.1.0-327.jar;hadoop-hdfs-2.7.1.2.4.1.0-327.jar;hadoop-mapreduce-client-common-2.7.1.2.4.1.0-327.jar;hadoop-mapreduce-client-core-2.7.1.2.4.1.0-327.jar;hadoop-mapreduce-client-jobclient-2.7.1.2.4.1.0-327.jar;hadoop-yarn-api-2.7.1.2.4.1.0-327.jar;hadoop-yarn-client-2.7.1.2.4.1.0-327.jar;hadoop-yarn-common-2.7.1.2.4.1.0-327.jar;hadoop-yarn-server-web-proxy-2.7.1.2.4.1.0-327.jar;htrace-core-3.2.0-incubating.jar;jackson-core-asl-1.9.14-TALEND.jar;jackson-mapper-asl-1.9.14-TALEND.jar;javax.ws.rs-api-2.1.jar;json_simple-1.1.jar;org.apache.commons.httpclient_3.1.0.v201012070820.jar;parquet-hadoop-bundle-1.6.0.jar;protobuf-java-2.5.0.jar;slf4j-api-1.7.5.jar;slf4j-log4j12-1.7.5.jar;snappy-java-1.0.5.jar;talend-bigdata-launcher-1.1.0-2016040.jar;talend-bigdata-launcher-1.1.0-20160405.jar;wsdl4j-1.6.3.jar";//$NON-NLS-1$
-        doTestClassLoader(EHadoopCategory.MAP_REDUCE.getName(), libsStr);
-    }
-
-    @Test
     public void testHive_NotSupport() {
         doTestNotSupportClassLoader(EHadoopCategory.HIVE.getName());
     }


### PR DESCRIPTION
The junit failed, just remove it, since it seems that no one cares the
junit and it will be removed from deprecated sooner or later

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
