### PR TITLE
fix(TBD-10093): XXX illegal pattern CDH61

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.cdh5x/resources/builtin/cdhx/Cloudera_CDH6_1_1.json
+++ b/main/plugins/org.talend.hadoop.distribution.cdh5x/resources/builtin/cdhx/Cloudera_CDH6_1_1.json
@@ -1224,6 +1224,10 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
+        "id" : "DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_jar",
+        "tagName" : "library"
+      }, {
+        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar",
         "tagName" : "library"
       }, {
@@ -1270,35 +1274,7 @@
     }, {
       "childNodes" : [ {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_HikariCP_java7_2_4_12_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -1310,10 +1286,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_apache_curator_2_12_0_pom",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar",
         "tagName" : "library"
       }, {
@@ -1322,23 +1294,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -1358,10 +1314,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_compiler_3_0_9_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar",
         "tagName" : "library"
       }, {
@@ -1375,14 +1327,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -1422,19 +1366,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_disruptor_3_3_6_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -1443,18 +1375,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_findbugs_annotations_1_3_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -1507,22 +1427,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -1602,67 +1506,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_hbase_handler_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -1687,10 +1531,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_4_10_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ivy_2_4_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -1735,22 +1575,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_janino_3_0_9_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -1854,19 +1678,11 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -1902,10 +1718,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_joni_2_1_11_jar",
         "tagName" : "library"
       }, {
@@ -1914,19 +1726,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -2006,14 +1806,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_9_3_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar",
         "tagName" : "library"
       }, {
@@ -2022,23 +1814,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_metrics_json_3_1_5_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_metrics_jvm_3_1_5_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_mssql_jdbc_6_2_1_jre7_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_objenesis_2_5_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -2047,14 +1823,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_oro_2_0_8_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -2090,10 +1858,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_parquet_jackson_1_9_0_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
@@ -2106,19 +1870,11 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_servlet_api_2_5_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_slf4j_log4j12_1_7_25_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -2130,15 +1886,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -2168,19 +1916,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_RoaringBitmap_0_5_11_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -2228,15 +1964,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_async_http_client_1_8_16_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -2245,18 +1973,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -2272,15 +1988,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_collections4_4_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_compiler_3_0_9_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -2400,10 +2108,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar",
         "tagName" : "library"
       }, {
@@ -2425,10 +2129,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_archives_3_0_0_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -2461,10 +2161,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_shim_0_9_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -2572,10 +2268,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
@@ -2584,7 +2276,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar",
+        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -2672,10 +2364,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ivy_2_4_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar",
         "tagName" : "library"
       }, {
@@ -2717,10 +2405,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_janino_3_0_9_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -3100,10 +2784,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_oro_2_0_8_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar",
         "tagName" : "library"
       }, {
@@ -3121,10 +2801,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_servlet_api_2_5_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -3148,10 +2824,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar",
         "tagName" : "library"
       }, {
@@ -3169,26 +2841,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_api_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_common_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_mapreduce_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_internals_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_library_0_9_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -3221,10 +2873,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -3290,19 +2938,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_RoaringBitmap_0_5_11_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -3350,15 +2986,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_async_http_client_1_8_16_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -3367,18 +2995,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -3394,15 +3010,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_collections4_4_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_compiler_3_0_9_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -3522,10 +3130,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar",
         "tagName" : "library"
       }, {
@@ -3547,10 +3151,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_archives_3_0_0_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -3583,10 +3183,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_shim_0_9_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -3694,10 +3290,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
@@ -3706,7 +3298,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar",
+        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -3794,10 +3386,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ivy_2_4_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar",
         "tagName" : "library"
       }, {
@@ -3839,10 +3427,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_janino_3_0_9_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -4222,10 +3806,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_oro_2_0_8_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar",
         "tagName" : "library"
       }, {
@@ -4243,10 +3823,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_servlet_api_2_5_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -4270,10 +3846,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar",
         "tagName" : "library"
       }, {
@@ -4291,26 +3863,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_api_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_common_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_mapreduce_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_internals_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_library_0_9_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -4343,10 +3895,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -4732,6 +4280,10 @@
     }, {
       "childNodes" : [ {
         "childNodes" : [ ],
+        "id" : "DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_jar",
+        "tagName" : "library"
+      }, {
+        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
@@ -5031,6 +4583,10 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar",
+        "tagName" : "library"
+      }, {
+        "childNodes" : [ ],
+        "id" : "DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -6028,19 +5584,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_RoaringBitmap_0_5_11_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -6088,10 +5632,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_async_http_client_1_8_16_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar",
         "tagName" : "library"
       }, {
@@ -6100,27 +5640,11 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -6136,15 +5660,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_collections4_4_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_compiler_3_0_9_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -6181,10 +5697,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -6264,10 +5776,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar",
         "tagName" : "library"
       }, {
@@ -6325,10 +5833,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_shim_0_9_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -6440,10 +5944,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
@@ -6456,7 +5956,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar",
+        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -6556,10 +6056,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ivy_2_4_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar",
         "tagName" : "library"
       }, {
@@ -6601,10 +6097,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_janino_3_0_9_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -7064,10 +6556,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar",
         "tagName" : "library"
       }, {
@@ -7085,26 +6573,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_api_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_common_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_mapreduce_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_internals_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_library_0_9_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -7137,10 +6605,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -7794,19 +7258,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_RoaringBitmap_0_5_11_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -7822,10 +7274,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_aopalliance_1_0_jar",
         "tagName" : "library"
       }, {
@@ -7834,31 +7282,11 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_async_http_client_1_8_16_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -7874,15 +7302,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_collections4_4_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_compiler_3_0_9_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -7895,10 +7315,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -7930,10 +7346,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_pool_1_6_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar",
         "tagName" : "library"
       }, {
@@ -7943,10 +7355,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -7978,10 +7386,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar",
         "tagName" : "library"
       }, {
@@ -8002,10 +7406,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_archives_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
@@ -8023,10 +7423,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_shim_0_9_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -8058,10 +7454,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
@@ -8070,19 +7462,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar",
+        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -8130,10 +7510,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ivy_2_4_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar",
         "tagName" : "library"
       }, {
@@ -8171,10 +7547,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jackson_xc_1_9_13_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_janino_3_0_9_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -8442,10 +7814,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_oro_2_0_8_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar",
         "tagName" : "library"
       }, {
@@ -8479,34 +7847,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_api_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_common_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_mapreduce_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_internals_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_library_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -9992,23 +9332,11 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_activation_1_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -10021,10 +9349,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_antlr4_runtime_4_7_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -10052,15 +9376,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_async_http_client_1_8_16_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -10073,18 +9389,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_avro_mapred_1_8_2_cdh6_1_1_hadoop2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -10105,10 +9409,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_collections4_4_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -10133,14 +9433,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -10216,10 +9508,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar",
         "tagName" : "library"
       }, {
@@ -10237,10 +9525,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_archives_3_0_0_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -10276,10 +9560,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_shim_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
@@ -10308,10 +9588,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
@@ -10320,31 +9596,11 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar",
+        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -10449,14 +9705,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_janino_3_0_9_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -10645,10 +9893,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -10796,10 +10040,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_oro_2_0_8_jar",
         "tagName" : "library"
       }, {
@@ -10829,10 +10069,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_1_9_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -10869,10 +10105,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_scala_xml_2_11_1_0_6_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_servlet_api_2_5_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -10940,31 +10172,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_stream_2_7_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_api_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_common_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_mapreduce_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_internals_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_library_0_9_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -10977,10 +10185,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11018,10 +10222,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar",
         "tagName" : "library"
       }, {
@@ -11030,27 +10230,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_antlr4_runtime_4_7_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11082,15 +10262,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_async_http_client_1_8_16_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11114,18 +10286,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_chill_2_11_0_9_3_jar",
         "tagName" : "library"
       }, {
@@ -11134,19 +10294,11 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_collections4_4_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11162,23 +10314,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_crypto_1_0_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11191,10 +10327,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11242,10 +10374,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar",
         "tagName" : "library"
       }, {
@@ -11254,19 +10382,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11286,19 +10402,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_archives_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_3_0_0_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11307,10 +10411,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_shim_0_9_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11326,15 +10426,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11342,63 +10434,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar",
+        "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11415,10 +10451,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_hppc_0_7_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11483,18 +10515,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_janino_3_0_9_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11594,19 +10614,11 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11626,31 +10638,11 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jetty_util_ajax_9_3_20_v20170531_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jline_2_12_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_jodd_core_3_5_2_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jsch_0_1_54_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11670,23 +10662,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -11878,10 +10854,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_parquet_jackson_1_9_0_cdh6_1_1_jar",
         "tagName" : "library"
       }, {
@@ -11918,10 +10890,6 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_servlet_api_2_5_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_shapeless_2_11_2_3_2_jar",
         "tagName" : "library"
       }, {
@@ -11931,10 +10899,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_slf4j_log4j12_1_7_25_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -12018,35 +10982,7 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_stream_2_7_0_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_api_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_common_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_mapreduce_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_internals_0_9_1_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_library_0_9_1_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -12059,14 +10995,6 @@
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar",
-        "tagName" : "library"
-      }, {
-        "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -12369,14 +11297,6 @@
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_SQOOP_PARQUET_LIB_DYNAMIC",
       "tagName" : "libraryNeededGroup",
       "templateId" : "SQOOP-PARQUET-LIB-DYNAMIC"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar",
-      "mvn_uri" : "mvn:org.antlr/ST4/4.0.4/jar",
-      "name" : "ST4-4.0.4.jar",
-      "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ {
         "childNodes" : [ ],
@@ -12891,14 +11811,6 @@
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar",
-      "mvn_uri" : "mvn:net.hydromatic/aggdesigner-algorithm/6.0/jar",
-      "name" : "aggdesigner-algorithm-6.0.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_amazon_kinesis_client_1_8_10_jar",
       "mvn_uri" : "mvn:com.amazonaws/amazon-kinesis-client/1.8.10/jar",
       "name" : "amazon-kinesis-client-1.8.10.jar",
@@ -12966,14 +11878,6 @@
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_aopalliance_repackaged_2_5_0_b32_jar",
       "mvn_uri" : "mvn:org.glassfish.hk2.external/aopalliance-repackaged/2.5.0-b32/jar",
       "name" : "aopalliance-repackaged-2.5.0-b32.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_apache_curator_2_12_0_pom",
-      "mvn_uri" : "mvn:org.apache.curator/apache-curator/2.12.0/pom",
-      "name" : "apache-curator-2.12.0.pom",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
@@ -13083,14 +11987,6 @@
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_async_http_client_1_8_16_jar",
-      "mvn_uri" : "mvn:com.ning/async-http-client/1.8.16/jar",
-      "name" : "async-http-client-1.8.16.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar",
       "mvn_uri" : "mvn:org.apache.yetus/audience-annotations/0.8.0/jar",
       "name" : "audience-annotations-0.8.0.jar",
@@ -13102,14 +11998,6 @@
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_automaton_1_11_8_jar",
       "mvn_uri" : "mvn:dk.brics.automaton/automaton/1.11-8/jar",
       "name" : "automaton-1.11-8.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar",
-      "mvn_uri" : "mvn:org.apache.calcite.avatica/avatica/1.12.0/jar",
-      "name" : "avatica-1.12.0.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
@@ -13132,7 +12020,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_avro_mapred_1_8_2_cdh6_1_1_hadoop2_jar",
-      "mvn_uri" : "mvn:org.apache.avro/avro-mapred/1.8.2-cdh6.1.1//hadoop2",
+      "mvn_uri" : "mvn:org.apache.avro/avro-mapred/1.8.2-cdh6.1.1/jar/hadoop2",
       "name" : "avro-mapred-1.8.2-cdh6.1.1-hadoop2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -13269,30 +12157,6 @@
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar",
-      "mvn_uri" : "mvn:org.apache.calcite/calcite-core/1.12.0/jar",
-      "name" : "calcite-core-1.12.0.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar",
-      "mvn_uri" : "mvn:org.apache.calcite/calcite-druid/1.12.0/jar",
-      "name" : "calcite-druid-1.12.0.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar",
-      "mvn_uri" : "mvn:org.apache.calcite/calcite-linq4j/1.12.0/jar",
-      "name" : "calcite-linq4j-1.12.0.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_chill_2_11_0_9_3_jar",
       "mvn_uri" : "mvn:com.twitter/chill_2.11/0.9.3/jar",
       "name" : "chill_2.11-0.9.3.jar",
@@ -13336,14 +12200,6 @@
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar",
       "mvn_uri" : "mvn:commons-codec/commons-codec/1.11/jar",
       "name" : "commons-codec-1.11.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_collections4_4_1_jar",
-      "mvn_uri" : "mvn:org.apache.commons/commons-collections4/4.1/jar",
-      "name" : "commons-collections4-4.1.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
@@ -13479,9 +12335,25 @@
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
+      "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_4_jar",
+      "mvn_uri" : "mvn:commons-lang/commons-lang/2.4/jar",
+      "name" : "commons-lang-2.4.jar",
+      "tagName" : "libraryNeeded"
+    }, {
+      "childNodes" : [ ],
+      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
+      "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar",
       "mvn_uri" : "mvn:commons-lang/commons-lang/2.6/jar",
       "name" : "commons-lang-2.6.jar",
+      "tagName" : "libraryNeeded"
+    }, {
+      "childNodes" : [ ],
+      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
+      "excludeDependencies" : "true",
+      "id" : "DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_1_1_jar",
+      "mvn_uri" : "mvn:commons-logging/commons-logging/1.1.1/jar",
+      "name" : "commons-logging-1.1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
@@ -13648,7 +12520,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_elephant_bird_core_4_9_jar",
-      "mvn_uri" : "mvn:com.twitter.elephantbird/elephant-bird-core/4.9/jar",
+      "mvn_uri" : "mvn:com.twitter.elephantbird/elephant-bird-core/4.9",
       "name" : "elephant-bird-core-4.9.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -13728,17 +12600,17 @@
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar",
-      "mvn_uri" : "mvn:org.codehaus.groovy/groovy-all/2.4.11/jar",
-      "name" : "groovy-all-2.4.11.jar",
+      "id" : "DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar",
+      "mvn_uri" : "mvn:com.google.code.gson/gson/2.2.4/jar",
+      "name" : "gson-2.2.4.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar",
-      "mvn_uri" : "mvn:com.google.code.gson/gson/2.2.4/jar",
-      "name" : "gson-2.2.4.jar",
+      "id" : "DYNAMIC_Cloudera_CDH6_1_1_guava_11_0_1_jar",
+      "mvn_uri" : "mvn:com.google.guava/guava/11.0.1/jar",
+      "name" : "guava-11.0.1.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
@@ -13882,7 +12754,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-mapreduce-client-core/3.0.0-cdh6.1.1",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-mapreduce-client-core/3.0.0-cdh6.1.1/jar",
       "name" : "hadoop-mapreduce-client-core-3.0.0-cdh6.1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -13900,14 +12772,6 @@
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_shuffle_2_7_1_jar",
       "mvn_uri" : "mvn:org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.1/jar",
       "name" : "hadoop-mapreduce-client-shuffle-2.7.1.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_shim_0_9_1_jar",
-      "mvn_uri" : "mvn:org.apache.tez/hadoop-shim/0.9.1/jar",
-      "name" : "hadoop-shim-0.9.1.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
@@ -13970,7 +12834,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-server-web-proxy/3.0.0-cdh6.1.1",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-server-web-proxy/3.0.0-cdh6.1.1/jar",
       "name" : "hadoop-yarn-server-web-proxy-3.0.0-cdh6.1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -14145,14 +13009,6 @@
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar",
-      "mvn_uri" : "mvn:org.apache.hive/hive-ant/2.1.1-cdh6.1.1/jar",
-      "name" : "hive-ant-2.1.1-cdh6.1.1.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar",
       "mvn_uri" : "mvn:org.apache.hive/hive-classification/2.1.1-cdh6.1.1/jar",
       "name" : "hive-classification-2.1.1-cdh6.1.1.jar",
@@ -14170,17 +13026,18 @@
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar",
-      "mvn_uri" : "mvn:org.apache.hive/hive-common/2.1.1-cdh6.1.1",
+      "mvn_uri" : "mvn:org.apache.hive/hive-common/2.1.1-cdh6.1.1/jar",
       "name" : "hive-common-2.1.1-cdh6.1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar",
-      "mvn_uri" : "mvn:org.apache.hive/hive-exec/2.1.1-cdh6.1.1/jar",
-      "name" : "hive-exec-2.1.1-cdh6.1.1.jar",
-      "tagName" : "libraryNeeded"
+      "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_exec",
+      "mvn_uri" : "mvn:org.talend.libraries/hive-exec-shade-2.1.1-cdh6.1.1/6.0.0",
+      "name" : "hive-exec-shade-2.1.1-cdh6.1.1.jar",
+      "tagName" : "libraryNeeded",
+      "useStudioRepository" : "true"
     }, {
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
@@ -14194,7 +13051,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_hcatalog_core_2_1_1_cdh6_1_1_jar",
-      "mvn_uri" : "mvn:org.apache.hive.hcatalog/hive-hcatalog-core/2.1.1-cdh6.1.1",
+      "mvn_uri" : "mvn:org.apache.hive.hcatalog/hive-hcatalog-core/2.1.1-cdh6.1.1/jar",
       "name" : "hive-hcatalog-core-2.1.1-cdh6.1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -14258,7 +13115,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_metastore_2_1_1_cdh6_1_1_jar",
-      "mvn_uri" : "mvn:org.apache.hive/hive-metastore/2.1.1-cdh6.1.1",
+      "mvn_uri" : "mvn:org.apache.hive/hive-metastore/2.1.1-cdh6.1.1/jar",
       "name" : "hive-metastore-2.1.1-cdh6.1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -14274,7 +13131,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar",
-      "mvn_uri" : "mvn:org.apache.hive/hive-serde/2.1.1-cdh6.1.1",
+      "mvn_uri" : "mvn:org.apache.hive/hive-serde/2.1.1-cdh6.1.1/jar",
       "name" : "hive-serde-2.1.1-cdh6.1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -14413,6 +13270,14 @@
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_httpclient_4_5_6_jar",
       "mvn_uri" : "mvn:org.apache.httpcomponents/httpclient/4.5.6/jar",
       "name" : "httpclient-4.5.6.jar",
+      "tagName" : "libraryNeeded"
+    }, {
+      "childNodes" : [ ],
+      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
+      "excludeDependencies" : "true",
+      "id" : "DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_0_1_jar",
+      "mvn_uri" : "mvn:org.apache.httpcomponents/httpcore/4.0.1/jar",
+      "name" : "httpcore-4.0.1.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
@@ -15148,6 +14013,14 @@
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
+      "id" : "DYNAMIC_Cloudera_CDH6_1_1_json_simple_1_1_jar",
+      "mvn_uri" : "mvn:com.googlecode.json-simple/json-simple/1.1/jar",
+      "name" : "json-simple-1.1.jar",
+      "tagName" : "libraryNeeded"
+    }, {
+      "childNodes" : [ ],
+      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
+      "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar",
       "mvn_uri" : "mvn:net.minidev/json-smart/2.3/jar",
       "name" : "json-smart-2.3.jar",
@@ -15239,6 +14112,14 @@
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_jython_standalone_2_7_0_jar",
       "mvn_uri" : "mvn:org.python/jython-standalone/2.7.0/jar",
       "name" : "jython-standalone-2.7.0.jar",
+      "tagName" : "libraryNeeded"
+    }, {
+      "childNodes" : [ ],
+      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
+      "excludeDependencies" : "true",
+      "id" : "DYNAMIC_Cloudera_CDH6_1_1_kafka_clients_0_10_0_kafka_2_1_2_jar",
+      "mvn_uri" : "mvn:org.apache.kafka/kafka-clients/0.10.0-kafka-2.1.2",
+      "name" : "kafka-clients-0.10.0-kafka-2.1.2.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
@@ -15415,6 +14296,14 @@
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar",
       "mvn_uri" : "mvn:org.apache.thrift/libfb303/0.9.3/jar",
       "name" : "libfb303-0.9.3.jar",
+      "tagName" : "libraryNeeded"
+    }, {
+      "childNodes" : [ ],
+      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
+      "excludeDependencies" : "true",
+      "id" : "DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_7_0_jar",
+      "mvn_uri" : "mvn:org.apache.thrift/libthrift/0.7.0/jar",
+      "name" : "libthrift-0.7.0.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
@@ -15660,7 +14549,7 @@
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_cdh6_1_1_jar",
+      "id" : "DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_jar",
       "mvn_uri" : "mvn:com.twitter/parquet-hadoop-bundle/1.6.0",
       "name" : "parquet-hadoop-bundle-1.6.0.jar",
       "tagName" : "libraryNeeded"
@@ -15693,7 +14582,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_pig_0_17_0_cdh6_1_1_jar",
-      "mvn_uri" : "mvn:org.apache.pig/pig/0.17.0-cdh6.1.1",
+      "mvn_uri" : "mvn:org.apache.pig/pig/0.17.0-cdh6.1.1/jar",
       "name" : "pig-0.17.0-cdh6.1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -15783,6 +14672,14 @@
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_servlet_api_2_5_6_1_14_jar",
       "mvn_uri" : "mvn:org.mortbay.jetty/servlet-api-2.5/6.1.14/jar",
       "name" : "servlet-api-2.5-6.1.14.jar",
+      "tagName" : "libraryNeeded"
+    }, {
+      "childNodes" : [ ],
+      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
+      "excludeDependencies" : "true",
+      "id" : "DYNAMIC_Cloudera_CDH6_1_1_servlet_api_2_5_jar",
+      "mvn_uri" : "mvn:javax.servlet/servlet-api/2.5/jar",
+      "name" : "servlet-api-2.5.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
@@ -16076,14 +14973,6 @@
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
       "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar",
-      "mvn_uri" : "mvn:stax/stax-api/1.0.1/jar",
-      "name" : "stax-api-1.0.1.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_2_jar",
       "mvn_uri" : "mvn:javax.xml.stream/stax-api/1.0-2/jar",
       "name" : "stax-api-1.0-2.jar",
@@ -16144,46 +15033,6 @@
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar",
       "mvn_uri" : "mvn:co.cask.tephra/tephra-hbase-compat-1.0/0.6.0/jar",
       "name" : "tephra-hbase-compat-1.0-0.6.0.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_api_0_9_1_jar",
-      "mvn_uri" : "mvn:org.apache.tez/tez-api/0.9.1/jar",
-      "name" : "tez-api-0.9.1.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_common_0_9_1_jar",
-      "mvn_uri" : "mvn:org.apache.tez/tez-common/0.9.1/jar",
-      "name" : "tez-common-0.9.1.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_mapreduce_0_9_1_jar",
-      "mvn_uri" : "mvn:org.apache.tez/tez-mapreduce/0.9.1/jar",
-      "name" : "tez-mapreduce-0.9.1.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_internals_0_9_1_jar",
-      "mvn_uri" : "mvn:org.apache.tez/tez-runtime-internals/0.9.1/jar",
-      "name" : "tez-runtime-internals-0.9.1.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_library_0_9_1_jar",
-      "mvn_uri" : "mvn:org.apache.tez/tez-runtime-library/0.9.1/jar",
-      "name" : "tez-runtime-library-0.9.1.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
@@ -16264,14 +15113,6 @@
       "id" : "DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar",
       "mvn_uri" : "mvn:javax.validation/validation-api/1.1.0.Final/jar",
       "name" : "validation-api-1.1.0.Final.jar",
-      "tagName" : "libraryNeeded"
-    }, {
-      "childNodes" : [ ],
-      "context" : "plugin:org.talend.hadoop.distribution.cdh5x",
-      "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar",
-      "mvn_uri" : "mvn:org.apache.velocity/velocity/1.7/jar",
-      "name" : "velocity-1.7.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
@@ -16377,37 +15218,37 @@
     "childNodes" : [ {
       "childNodes" : [ ],
       "index" : "HDFS:CLOUDERA:Cloudera_CDH6_1_1",
-      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_cdh6_1_1_jar",
+      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar",
       "moduleGroupTemplateId" : "HDFS-LIB-DYNAMIC",
       "tagName" : "classloader"
     }, {
       "childNodes" : [ ],
       "index" : "HDFS:CLOUDERA:Cloudera_CDH6_1_1?USE_KRB",
-      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_cdh6_1_1_jar",
+      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar",
       "moduleGroupTemplateId" : "HDFS-LIB-DYNAMIC",
       "tagName" : "classloader"
     }, {
       "childNodes" : [ ],
       "index" : "HIVE:CLOUDERA:Cloudera_CDH6_1_1:EMBEDDED",
-      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_HikariCP_2_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_HikariCP_java7_2_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_RoaringBitmap_0_5_11_jar;DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_repackaged_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jsp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jstl_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_commons_5_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_tree_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_async_http_client_1_8_16_jar;DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections4_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compiler_3_0_9_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_pool_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_api_jdo_4_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_rdbms_4_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_derby_10_14_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_disruptor_3_3_6_jar;DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ecj_4_4_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fastutil_7_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_findbugs_annotations_1_3_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar;DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar;DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_assistedinject_3_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_servlet_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_archives_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_shim_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_registry_2_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hamcrest_core_1_3_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_client_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_common_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop2_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_http_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_mapreduce_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_api_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_procedure_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_shaded_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_replication_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_server_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_miscellaneous_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_netty_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_protobuf_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_zookeeper_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_jdbc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_server_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_metastore_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_api_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_locator_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_utils_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_httpclient_4_5_6_jar;DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_4_10_jar;DYNAMIC_Cloudera_CDH6_1_1_ivy_2_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_xc_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_janino_3_0_9_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javassist_3_20_0_GA_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_annotation_api_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_jdo_3_2_0_m3_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_2_3_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_api_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_ws_rs_api_2_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javolution_5_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_impl_2_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcodings_1_0_18_jar;DYNAMIC_Cloudera_CDH6_1_1_jcommander_1_30_jar;DYNAMIC_Cloudera_CDH6_1_1_jdo_api_3_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_common_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_container_servlet_core_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guava_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guice_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_json_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_media_jaxb_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jettison_1_3_8_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_annotations_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jaas_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jndi_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_plus_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_runner_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_schemas_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_ajax_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jline_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar;DYNAMIC_Cloudera_CDH6_1_1_joni_2_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_jpam_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsch_0_1_54_jar;DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar;DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jta_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_junit_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_leveldbjni_all_1_8_jar;DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_core_3_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_json_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_jvm_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_mssql_jdbc_6_2_1_jre7_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_3_10_6_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_all_4_1_17_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_objenesis_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_oro_2_0_8_jar;DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_servlet_api_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_slider_core_0_90_2_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_spec_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_api_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_core_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_api_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_common_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_mapreduce_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_internals_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_library_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_transaction_api_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_common_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_zookeeper_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_api_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_common_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_zookeeper_3_4_6_jar",
+      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_HikariCP_2_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_HikariCP_java7_2_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_repackaged_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jsp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jstl_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_commons_5_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_tree_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_pool_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_api_jdo_4_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_rdbms_4_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_derby_10_14_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_disruptor_3_3_6_jar;DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ecj_4_4_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fastutil_7_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_findbugs_annotations_1_3_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar;DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_assistedinject_3_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_servlet_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_registry_2_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hamcrest_core_1_3_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_client_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_common_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop2_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_http_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_mapreduce_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_api_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_procedure_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_shaded_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_replication_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_server_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_miscellaneous_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_netty_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_protobuf_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_zookeeper_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_exec;DYNAMIC_Cloudera_CDH6_1_1_hive_jdbc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_server_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_metastore_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_api_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_locator_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_utils_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_httpclient_4_5_6_jar;DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_4_10_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_xc_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javassist_3_20_0_GA_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_annotation_api_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_jdo_3_2_0_m3_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_2_3_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_api_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_ws_rs_api_2_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javolution_5_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_impl_2_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcodings_1_0_18_jar;DYNAMIC_Cloudera_CDH6_1_1_jcommander_1_30_jar;DYNAMIC_Cloudera_CDH6_1_1_jdo_api_3_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_common_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_container_servlet_core_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guava_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guice_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_json_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_media_jaxb_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jettison_1_3_8_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_annotations_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jaas_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jndi_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_plus_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_runner_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_schemas_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_ajax_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jline_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar;DYNAMIC_Cloudera_CDH6_1_1_joni_2_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_jpam_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsch_0_1_54_jar;DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar;DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jta_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_junit_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_leveldbjni_all_1_8_jar;DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_core_3_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_json_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_jvm_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_mssql_jdbc_6_2_1_jre7_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_3_10_6_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_all_4_1_17_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_objenesis_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_slider_core_0_90_2_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_spec_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_api_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_core_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_transaction_api_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_common_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_zookeeper_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_api_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_common_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_zookeeper_3_4_6_jar",
       "moduleGroupTemplateId" : "HIVE-LIB-DYNAMIC",
       "tagName" : "classloader"
     }, {
       "childNodes" : [ ],
       "index" : "HIVE:CLOUDERA:Cloudera_CDH6_1_1:STANDALONE",
-      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_HikariCP_2_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_HikariCP_java7_2_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_RoaringBitmap_0_5_11_jar;DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_repackaged_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jsp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jstl_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_commons_5_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_tree_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_async_http_client_1_8_16_jar;DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections4_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compiler_3_0_9_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_pool_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_api_jdo_4_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_rdbms_4_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_derby_10_14_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_disruptor_3_3_6_jar;DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ecj_4_4_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fastutil_7_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_findbugs_annotations_1_3_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar;DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar;DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_assistedinject_3_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_servlet_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_archives_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_shim_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_registry_2_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hamcrest_core_1_3_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_client_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_common_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop2_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_http_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_mapreduce_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_api_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_procedure_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_shaded_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_replication_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_server_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_miscellaneous_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_netty_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_protobuf_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_zookeeper_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_jdbc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_server_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_metastore_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_api_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_locator_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_utils_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_httpclient_4_5_6_jar;DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_4_10_jar;DYNAMIC_Cloudera_CDH6_1_1_ivy_2_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_xc_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_janino_3_0_9_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javassist_3_20_0_GA_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_annotation_api_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_jdo_3_2_0_m3_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_2_3_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_api_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_ws_rs_api_2_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javolution_5_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_impl_2_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcodings_1_0_18_jar;DYNAMIC_Cloudera_CDH6_1_1_jcommander_1_30_jar;DYNAMIC_Cloudera_CDH6_1_1_jdo_api_3_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_common_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_container_servlet_core_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guava_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guice_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_json_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_media_jaxb_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jettison_1_3_8_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_annotations_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jaas_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jndi_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_plus_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_runner_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_schemas_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_ajax_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jline_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar;DYNAMIC_Cloudera_CDH6_1_1_joni_2_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_jpam_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsch_0_1_54_jar;DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar;DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jta_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_junit_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_leveldbjni_all_1_8_jar;DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_core_3_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_json_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_jvm_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_mssql_jdbc_6_2_1_jre7_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_3_10_6_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_all_4_1_17_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_objenesis_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_oro_2_0_8_jar;DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_servlet_api_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_slider_core_0_90_2_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_spec_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_api_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_core_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_api_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_common_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_mapreduce_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_internals_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_library_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_transaction_api_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_common_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_zookeeper_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_api_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_common_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_zookeeper_3_4_6_jar",
+      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_HikariCP_2_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_HikariCP_java7_2_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_repackaged_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jsp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jstl_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_commons_5_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_tree_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_pool_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_api_jdo_4_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_rdbms_4_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_derby_10_14_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_disruptor_3_3_6_jar;DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ecj_4_4_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fastutil_7_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_findbugs_annotations_1_3_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar;DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_assistedinject_3_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_servlet_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_registry_2_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hamcrest_core_1_3_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_client_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_common_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop2_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_http_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_mapreduce_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_api_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_procedure_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_shaded_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_replication_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_server_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_miscellaneous_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_netty_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_protobuf_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_zookeeper_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_exec;DYNAMIC_Cloudera_CDH6_1_1_hive_jdbc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_server_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_metastore_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_api_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_locator_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_utils_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_httpclient_4_5_6_jar;DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_4_10_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_xc_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javassist_3_20_0_GA_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_annotation_api_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_jdo_3_2_0_m3_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_2_3_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_api_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_ws_rs_api_2_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javolution_5_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_impl_2_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcodings_1_0_18_jar;DYNAMIC_Cloudera_CDH6_1_1_jcommander_1_30_jar;DYNAMIC_Cloudera_CDH6_1_1_jdo_api_3_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_common_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_container_servlet_core_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guava_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guice_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_json_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_media_jaxb_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jettison_1_3_8_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_annotations_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jaas_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jndi_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_plus_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_runner_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_schemas_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_ajax_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jline_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar;DYNAMIC_Cloudera_CDH6_1_1_joni_2_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_jpam_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsch_0_1_54_jar;DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar;DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jta_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_junit_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_leveldbjni_all_1_8_jar;DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_core_3_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_json_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_jvm_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_mssql_jdbc_6_2_1_jre7_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_3_10_6_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_all_4_1_17_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_objenesis_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_slider_core_0_90_2_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_spec_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_api_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_core_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_transaction_api_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_common_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_zookeeper_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_api_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_common_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_zookeeper_3_4_6_jar",
       "moduleGroupTemplateId" : "HIVE-LIB-DYNAMIC",
       "tagName" : "classloader"
     }, {
       "childNodes" : [ ],
       "index" : "HIVE2:CLOUDERA:Cloudera_CDH6_1_1:EMBEDDED",
-      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_HikariCP_2_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_HikariCP_java7_2_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_RoaringBitmap_0_5_11_jar;DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_repackaged_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jsp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jstl_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_commons_5_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_tree_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_async_http_client_1_8_16_jar;DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections4_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compiler_3_0_9_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_pool_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_api_jdo_4_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_rdbms_4_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_derby_10_14_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_disruptor_3_3_6_jar;DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ecj_4_4_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fastutil_7_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_findbugs_annotations_1_3_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar;DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar;DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_assistedinject_3_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_servlet_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_archives_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_shim_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_registry_2_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hamcrest_core_1_3_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_client_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_common_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop2_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_http_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_mapreduce_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_api_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_procedure_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_shaded_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_replication_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_server_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_miscellaneous_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_netty_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_protobuf_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_zookeeper_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_jdbc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_server_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_metastore_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_api_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_locator_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_utils_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_httpclient_4_5_6_jar;DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_4_10_jar;DYNAMIC_Cloudera_CDH6_1_1_ivy_2_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_xc_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_janino_3_0_9_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javassist_3_20_0_GA_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_annotation_api_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_jdo_3_2_0_m3_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_2_3_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_api_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_ws_rs_api_2_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javolution_5_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_impl_2_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcodings_1_0_18_jar;DYNAMIC_Cloudera_CDH6_1_1_jcommander_1_30_jar;DYNAMIC_Cloudera_CDH6_1_1_jdo_api_3_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_common_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_container_servlet_core_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guava_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guice_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_json_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_media_jaxb_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jettison_1_3_8_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_annotations_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jaas_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jndi_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_plus_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_runner_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_schemas_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_ajax_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jline_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar;DYNAMIC_Cloudera_CDH6_1_1_joni_2_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_jpam_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsch_0_1_54_jar;DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar;DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jta_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_junit_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_leveldbjni_all_1_8_jar;DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_core_3_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_json_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_jvm_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_mssql_jdbc_6_2_1_jre7_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_3_10_6_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_all_4_1_17_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_objenesis_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_oro_2_0_8_jar;DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_servlet_api_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_slider_core_0_90_2_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_spec_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_api_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_core_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_api_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_common_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_mapreduce_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_internals_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_library_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_transaction_api_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_common_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_zookeeper_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_api_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_common_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_zookeeper_3_4_6_jar",
+      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_HikariCP_2_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_HikariCP_java7_2_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_repackaged_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jsp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jstl_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_commons_5_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_tree_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_pool_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_api_jdo_4_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_rdbms_4_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_derby_10_14_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_disruptor_3_3_6_jar;DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ecj_4_4_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fastutil_7_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_findbugs_annotations_1_3_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar;DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_assistedinject_3_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_servlet_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_registry_2_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hamcrest_core_1_3_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_client_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_common_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop2_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_http_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_mapreduce_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_api_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_procedure_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_shaded_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_replication_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_server_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_miscellaneous_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_netty_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_protobuf_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_zookeeper_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_exec;DYNAMIC_Cloudera_CDH6_1_1_hive_jdbc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_server_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_metastore_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_api_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_locator_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_utils_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_httpclient_4_5_6_jar;DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_4_10_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_xc_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javassist_3_20_0_GA_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_annotation_api_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_jdo_3_2_0_m3_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_2_3_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_api_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_ws_rs_api_2_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javolution_5_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_impl_2_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcodings_1_0_18_jar;DYNAMIC_Cloudera_CDH6_1_1_jcommander_1_30_jar;DYNAMIC_Cloudera_CDH6_1_1_jdo_api_3_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_common_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_container_servlet_core_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guava_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guice_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_json_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_media_jaxb_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jettison_1_3_8_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_annotations_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jaas_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jndi_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_plus_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_runner_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_schemas_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_ajax_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jline_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar;DYNAMIC_Cloudera_CDH6_1_1_joni_2_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_jpam_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsch_0_1_54_jar;DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar;DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jta_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_junit_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_leveldbjni_all_1_8_jar;DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_core_3_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_json_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_jvm_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_mssql_jdbc_6_2_1_jre7_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_3_10_6_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_all_4_1_17_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_objenesis_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_slider_core_0_90_2_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_spec_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_api_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_core_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_transaction_api_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_common_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_zookeeper_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_api_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_common_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_zookeeper_3_4_6_jar",
       "moduleGroupTemplateId" : "HIVE-LIB-DYNAMIC",
       "tagName" : "classloader"
     }, {
       "childNodes" : [ ],
       "index" : "HIVE2:CLOUDERA:Cloudera_CDH6_1_1:STANDALONE",
-      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_HikariCP_2_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_HikariCP_java7_2_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_RoaringBitmap_0_5_11_jar;DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_repackaged_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jsp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jstl_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_commons_5_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_tree_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_async_http_client_1_8_16_jar;DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections4_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compiler_3_0_9_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_pool_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_api_jdo_4_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_rdbms_4_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_derby_10_14_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_disruptor_3_3_6_jar;DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ecj_4_4_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fastutil_7_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_findbugs_annotations_1_3_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar;DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar;DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_assistedinject_3_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_servlet_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_archives_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_shim_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_registry_2_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hamcrest_core_1_3_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_client_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_common_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop2_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_http_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_mapreduce_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_api_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_procedure_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_shaded_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_replication_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_server_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_miscellaneous_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_netty_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_protobuf_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_zookeeper_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_jdbc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_server_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_metastore_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_api_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_locator_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_utils_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_httpclient_4_5_6_jar;DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_4_10_jar;DYNAMIC_Cloudera_CDH6_1_1_ivy_2_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_xc_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_janino_3_0_9_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javassist_3_20_0_GA_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_annotation_api_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_jdo_3_2_0_m3_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_2_3_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_api_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_ws_rs_api_2_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javolution_5_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_impl_2_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcodings_1_0_18_jar;DYNAMIC_Cloudera_CDH6_1_1_jcommander_1_30_jar;DYNAMIC_Cloudera_CDH6_1_1_jdo_api_3_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_common_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_container_servlet_core_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guava_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guice_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_json_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_media_jaxb_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jettison_1_3_8_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_annotations_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jaas_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jndi_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_plus_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_runner_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_schemas_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_ajax_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jline_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar;DYNAMIC_Cloudera_CDH6_1_1_joni_2_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_jpam_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsch_0_1_54_jar;DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar;DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jta_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_junit_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_leveldbjni_all_1_8_jar;DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_core_3_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_json_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_jvm_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_mssql_jdbc_6_2_1_jre7_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_3_10_6_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_all_4_1_17_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_objenesis_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_oro_2_0_8_jar;DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_servlet_api_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_slider_core_0_90_2_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_spec_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_api_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_core_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_api_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_common_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_mapreduce_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_internals_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_library_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_transaction_api_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_common_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_zookeeper_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_api_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_common_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_zookeeper_3_4_6_jar",
+      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_HikariCP_2_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_HikariCP_java7_2_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_repackaged_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jsp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jstl_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_commons_5_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_tree_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_pool_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_api_jdo_4_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_rdbms_4_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_derby_10_14_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_disruptor_3_3_6_jar;DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ecj_4_4_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fastutil_7_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_findbugs_annotations_1_3_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar;DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_assistedinject_3_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_servlet_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_registry_2_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hamcrest_core_1_3_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_client_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_common_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop2_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_http_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_mapreduce_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_api_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_procedure_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_shaded_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_replication_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_server_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_miscellaneous_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_netty_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_protobuf_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_zookeeper_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_exec;DYNAMIC_Cloudera_CDH6_1_1_hive_jdbc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_server_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_metastore_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_api_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_locator_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_utils_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_httpclient_4_5_6_jar;DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_4_10_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_xc_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javassist_3_20_0_GA_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_annotation_api_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_jdo_3_2_0_m3_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_2_3_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_api_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_ws_rs_api_2_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javolution_5_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_impl_2_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcodings_1_0_18_jar;DYNAMIC_Cloudera_CDH6_1_1_jcommander_1_30_jar;DYNAMIC_Cloudera_CDH6_1_1_jdo_api_3_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_common_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_container_servlet_core_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guava_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guice_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_json_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_media_jaxb_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jettison_1_3_8_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_annotations_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jaas_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jndi_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_plus_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_runner_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_schemas_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_ajax_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jline_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar;DYNAMIC_Cloudera_CDH6_1_1_joni_2_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_jpam_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsch_0_1_54_jar;DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar;DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jta_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_junit_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_leveldbjni_all_1_8_jar;DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_core_3_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_json_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_jvm_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_mssql_jdbc_6_2_1_jre7_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_3_10_6_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_all_4_1_17_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_objenesis_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_slider_core_0_90_2_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_spec_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_api_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_core_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_transaction_api_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_common_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_zookeeper_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_api_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_common_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_zookeeper_3_4_6_jar",
       "moduleGroupTemplateId" : "HIVE-LIB-DYNAMIC",
       "tagName" : "classloader"
     }, {
@@ -16425,13 +15266,13 @@
     }, {
       "childNodes" : [ ],
       "index" : "IMPALA:CLOUDERA:Cloudera_CDH6_1_1",
-      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_HikariCP_2_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_HikariCP_java7_2_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_RoaringBitmap_0_5_11_jar;DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_repackaged_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jsp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jstl_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_commons_5_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_tree_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_async_http_client_1_8_16_jar;DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections4_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compiler_3_0_9_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_pool_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_api_jdo_4_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_rdbms_4_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_derby_10_14_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_disruptor_3_3_6_jar;DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ecj_4_4_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fastutil_7_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_findbugs_annotations_1_3_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar;DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar;DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_assistedinject_3_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_servlet_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_archives_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_shim_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_registry_2_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hamcrest_core_1_3_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_client_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_common_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop2_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_http_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_mapreduce_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_api_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_procedure_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_shaded_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_replication_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_server_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_miscellaneous_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_netty_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_protobuf_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_zookeeper_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_jdbc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_server_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_metastore_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_api_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_locator_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_utils_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_httpclient_4_5_6_jar;DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_4_10_jar;DYNAMIC_Cloudera_CDH6_1_1_ivy_2_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_xc_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_janino_3_0_9_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javassist_3_20_0_GA_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_annotation_api_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_jdo_3_2_0_m3_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_2_3_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_api_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_ws_rs_api_2_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javolution_5_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_impl_2_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcodings_1_0_18_jar;DYNAMIC_Cloudera_CDH6_1_1_jcommander_1_30_jar;DYNAMIC_Cloudera_CDH6_1_1_jdo_api_3_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_common_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_container_servlet_core_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guava_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guice_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_json_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_media_jaxb_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jettison_1_3_8_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_annotations_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jaas_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jndi_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_plus_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_runner_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_schemas_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_ajax_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jline_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar;DYNAMIC_Cloudera_CDH6_1_1_joni_2_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_jpam_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsch_0_1_54_jar;DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar;DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jta_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_junit_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_leveldbjni_all_1_8_jar;DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_core_3_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_json_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_jvm_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_mssql_jdbc_6_2_1_jre7_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_3_10_6_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_all_4_1_17_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_objenesis_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_oro_2_0_8_jar;DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_servlet_api_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_slider_core_0_90_2_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_spec_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_api_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_core_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_api_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_common_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_mapreduce_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_internals_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_library_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_transaction_api_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_common_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_zookeeper_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_api_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_common_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_zookeeper_3_4_6_jar",
+      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_HikariCP_2_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_HikariCP_java7_2_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_repackaged_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jsp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jstl_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_commons_5_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_tree_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_pool_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_api_jdo_4_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_rdbms_4_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_derby_10_14_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_disruptor_3_3_6_jar;DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ecj_4_4_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fastutil_7_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_findbugs_annotations_1_3_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar;DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_assistedinject_3_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_servlet_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_registry_2_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hamcrest_core_1_3_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_client_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_common_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop2_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_http_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_mapreduce_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_api_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_procedure_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_shaded_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_replication_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_server_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_miscellaneous_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_netty_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_protobuf_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_zookeeper_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_exec;DYNAMIC_Cloudera_CDH6_1_1_hive_jdbc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_server_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_metastore_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_api_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_locator_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_utils_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_httpclient_4_5_6_jar;DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_4_10_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_xc_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javassist_3_20_0_GA_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_annotation_api_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_jdo_3_2_0_m3_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_2_3_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_api_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_ws_rs_api_2_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javolution_5_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_impl_2_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcodings_1_0_18_jar;DYNAMIC_Cloudera_CDH6_1_1_jcommander_1_30_jar;DYNAMIC_Cloudera_CDH6_1_1_jdo_api_3_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_common_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_container_servlet_core_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guava_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guice_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_json_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_media_jaxb_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jettison_1_3_8_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_annotations_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jaas_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jndi_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_plus_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_runner_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_schemas_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_ajax_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jline_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar;DYNAMIC_Cloudera_CDH6_1_1_joni_2_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_jpam_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsch_0_1_54_jar;DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar;DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jta_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_junit_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_leveldbjni_all_1_8_jar;DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_core_3_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_json_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_jvm_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_mssql_jdbc_6_2_1_jre7_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_3_10_6_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_all_4_1_17_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_objenesis_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_slider_core_0_90_2_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_spec_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_api_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_core_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_transaction_api_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_common_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_zookeeper_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_api_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_common_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_zookeeper_3_4_6_jar",
       "moduleGroupTemplateId" : "IMPALA-LIB-DYNAMIC",
       "tagName" : "classloader"
     }, {
       "childNodes" : [ ],
       "index" : "IMPALA:CLOUDERA:Cloudera_CDH6_1_1?USE_KRB",
-      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_HikariCP_2_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_HikariCP_java7_2_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_RoaringBitmap_0_5_11_jar;DYNAMIC_Cloudera_CDH6_1_1_ST4_4_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aggdesigner_algorithm_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_repackaged_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jsp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jstl_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_commons_5_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_tree_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_async_http_client_1_8_16_jar;DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avatica_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_core_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_druid_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_calcite_linq4j_1_12_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections4_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compiler_3_0_9_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_pool_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_api_jdo_4_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_rdbms_4_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_derby_10_14_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_disruptor_3_3_6_jar;DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ecj_4_4_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fastutil_7_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_findbugs_annotations_1_3_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar;DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar;DYNAMIC_Cloudera_CDH6_1_1_groovy_all_2_4_11_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_assistedinject_3_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_servlet_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_archives_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_shim_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_registry_2_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hamcrest_core_1_3_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_client_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_common_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop2_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_http_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_mapreduce_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_api_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_procedure_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_shaded_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_replication_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_server_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_miscellaneous_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_netty_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_protobuf_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_zookeeper_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_ant_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_exec_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_jdbc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_server_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_metastore_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_api_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_locator_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_utils_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_httpclient_4_5_6_jar;DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_4_10_jar;DYNAMIC_Cloudera_CDH6_1_1_ivy_2_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_xc_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_janino_3_0_9_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javassist_3_20_0_GA_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_annotation_api_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_jdo_3_2_0_m3_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_2_3_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_api_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_ws_rs_api_2_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javolution_5_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_impl_2_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcodings_1_0_18_jar;DYNAMIC_Cloudera_CDH6_1_1_jcommander_1_30_jar;DYNAMIC_Cloudera_CDH6_1_1_jdo_api_3_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_common_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_container_servlet_core_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guava_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guice_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_json_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_media_jaxb_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jettison_1_3_8_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_annotations_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jaas_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jndi_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_plus_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_runner_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_schemas_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_ajax_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jline_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar;DYNAMIC_Cloudera_CDH6_1_1_joni_2_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_jpam_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsch_0_1_54_jar;DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar;DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jta_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_junit_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_leveldbjni_all_1_8_jar;DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_core_3_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_json_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_jvm_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_mssql_jdbc_6_2_1_jre7_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_3_10_6_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_all_4_1_17_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_objenesis_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_oro_2_0_8_jar;DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_6_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_servlet_api_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_slider_core_0_90_2_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_stax_api_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_spec_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_api_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_core_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_api_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_common_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_mapreduce_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_internals_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_tez_runtime_library_0_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_transaction_api_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_common_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_zookeeper_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_velocity_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_api_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_common_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_zookeeper_3_4_6_jar",
+      "libraries" : "DYNAMIC_Cloudera_CDH6_1_1_HikariCP_2_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_HikariCP_java7_2_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_accessors_smart_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_6_5_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_ant_launcher_1_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_antlr_runtime_3_5_2_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_aopalliance_repackaged_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jsp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_apache_jstl_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_commons_5_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_asm_tree_5_0_4_jar;DYNAMIC_Cloudera_CDH6_1_1_audience_annotations_0_8_0_jar;DYNAMIC_Cloudera_CDH6_1_1_avro_1_8_2_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_bonecp_0_8_0_RELEASE_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_beanutils_1_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_cli_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_codec_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_collections_3_2_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_compress_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_configuration2_2_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_daemon_1_0_13_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_dbcp_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_el_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_httpclient_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_io_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang3_3_7_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_lang_2_6_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_logging_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_math3_3_6_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_net_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_commons_pool_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_client_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_framework_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_curator_recipes_4_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_api_jdo_4_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_core_4_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_datanucleus_rdbms_4_1_7_jar;DYNAMIC_Cloudera_CDH6_1_1_derby_10_14_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_disruptor_3_3_6_jar;DYNAMIC_Cloudera_CDH6_1_1_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ecj_4_4_2_jar;DYNAMIC_Cloudera_CDH6_1_1_ehcache_3_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fastutil_7_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_findbugs_annotations_1_3_9_1_jar;DYNAMIC_Cloudera_CDH6_1_1_fst_2_50_jar;DYNAMIC_Cloudera_CDH6_1_1_geronimo_jcache_1_0_spec_1_0_alpha_1_jar;DYNAMIC_Cloudera_CDH6_1_1_gson_2_2_4_jar;DYNAMIC_Cloudera_CDH6_1_1_guava_14_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_assistedinject_3_0_jar;DYNAMIC_Cloudera_CDH6_1_1_guice_servlet_4_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_annotations_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_auth_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_hdfs_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_core_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_mapreduce_client_jobclient_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_api_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_client_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_registry_2_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_applicationhistoryservice_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_common_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_resourcemanager_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hadoop_yarn_server_web_proxy_3_0_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hamcrest_core_1_3_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_client_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_common_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop2_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_hadoop_compat_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_http_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_mapreduce_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_metrics_api_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_procedure_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_protocol_shaded_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_replication_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_server_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_miscellaneous_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_netty_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_shaded_protobuf_2_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_hbase_zookeeper_2_1_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_classification_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_exec;DYNAMIC_Cloudera_CDH6_1_1_hive_jdbc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_client_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_server_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_llap_tez_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_metastore_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_orc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_serde_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_service_rpc_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_0_23_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_common_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_shims_scheduler_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hive_storage_api_2_1_1_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_api_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_locator_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_hk2_utils_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_htrace_core4_4_2_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_httpclient_4_5_6_jar;DYNAMIC_Cloudera_CDH6_1_1_httpcore_4_4_10_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_core_asl_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_databind_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_base_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_jaxrs_json_provider_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_mapper_asl_1_9_13_cloudera_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_module_jaxb_annotations_2_9_5_jar;DYNAMIC_Cloudera_CDH6_1_1_jackson_xc_1_9_13_jar;DYNAMIC_Cloudera_CDH6_1_1_jamon_runtime_2_4_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_compiler_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_jasper_runtime_5_5_23_jar;DYNAMIC_Cloudera_CDH6_1_1_java_util_1_9_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javassist_3_20_0_GA_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_annotation_api_1_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_inject_2_5_0_b32_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_jdo_3_2_0_m3_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_api_3_1_0_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_2_3_2_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_servlet_jsp_api_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javax_ws_rs_api_2_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_javolution_5_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_api_2_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_jaxb_impl_2_2_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcip_annotations_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jcodings_1_0_18_jar;DYNAMIC_Cloudera_CDH6_1_1_jcommander_1_30_jar;DYNAMIC_Cloudera_CDH6_1_1_jdo_api_3_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_client_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_common_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_container_servlet_core_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_core_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guava_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_guice_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_json_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_media_jaxb_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_server_2_25_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jersey_servlet_1_19_jar;DYNAMIC_Cloudera_CDH6_1_1_jettison_1_3_8_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_annotations_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_http_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_io_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jaas_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_jndi_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_plus_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_rewrite_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_runner_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_schemas_3_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_security_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_6_1_26_cloudera_4_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_util_ajax_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_webapp_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jetty_xml_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_jline_2_12_jar;DYNAMIC_Cloudera_CDH6_1_1_joda_time_2_9_9_jar;DYNAMIC_Cloudera_CDH6_1_1_joni_2_1_11_jar;DYNAMIC_Cloudera_CDH6_1_1_jpam_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsch_0_1_54_jar;DYNAMIC_Cloudera_CDH6_1_1_json_20090211_jar;DYNAMIC_Cloudera_CDH6_1_1_json_io_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_json_smart_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsp_api_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr305_3_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_jsr311_api_1_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_jta_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_junit_4_12_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_admin_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_client_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_common_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_core_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_crypto_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_identity_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_server_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_simplekdc_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerb_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_asn1_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_config_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_pkix_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_util_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_kerby_xdr_1_0_0_jar;DYNAMIC_Cloudera_CDH6_1_1_leveldbjni_all_1_8_jar;DYNAMIC_Cloudera_CDH6_1_1_libfb303_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_libthrift_0_9_3_jar;DYNAMIC_Cloudera_CDH6_1_1_log4j_1_2_17_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_core_3_2_1_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_json_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_metrics_jvm_3_1_5_jar;DYNAMIC_Cloudera_CDH6_1_1_mssql_jdbc_6_2_1_jre7_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_3_10_6_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_netty_all_4_1_17_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_nimbus_jose_jwt_4_41_1_jar;DYNAMIC_Cloudera_CDH6_1_1_objenesis_2_5_1_jar;DYNAMIC_Cloudera_CDH6_1_1_okhttp_2_7_5_jar;DYNAMIC_Cloudera_CDH6_1_1_okio_1_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_opencsv_2_3_jar;DYNAMIC_Cloudera_CDH6_1_1_osgi_resource_locator_1_0_1_jar;DYNAMIC_Cloudera_CDH6_1_1_paranamer_2_8_jar;DYNAMIC_Cloudera_CDH6_1_1_parquet_hadoop_bundle_1_9_0_cdh6_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_protobuf_java_2_5_0_jar;DYNAMIC_Cloudera_CDH6_1_1_re2j_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_slf4j_api_1_7_25_jar;DYNAMIC_Cloudera_CDH6_1_1_slider_core_0_90_2_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_0_2_jar;DYNAMIC_Cloudera_CDH6_1_1_snappy_java_1_1_7_1_jar;DYNAMIC_Cloudera_CDH6_1_1_stax2_api_3_1_4_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_impl_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_taglibs_standard_spec_1_2_5_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_api_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_core_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_tephra_hbase_compat_1_0_0_6_0_jar;DYNAMIC_Cloudera_CDH6_1_1_transaction_api_1_1_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_common_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_api_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_discovery_core_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_twill_zookeeper_0_6_0_incubating_jar;DYNAMIC_Cloudera_CDH6_1_1_validation_api_1_1_0_Final_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_api_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_client_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_common_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_server_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_websocket_servlet_9_3_20_v20170531_jar;DYNAMIC_Cloudera_CDH6_1_1_woodstox_core_5_0_3_jar;DYNAMIC_Cloudera_CDH6_1_1_xz_1_6_jar;DYNAMIC_Cloudera_CDH6_1_1_zookeeper_3_4_6_jar",
       "moduleGroupTemplateId" : "IMPALA-LIB-DYNAMIC",
       "tagName" : "classloader"
     } ],

--- a/main/plugins/org.talend.hadoop.distribution.cdh5x/resources/template/cdhx/cdh6xTemplate.json
+++ b/main/plugins/org.talend.hadoop.distribution.cdh5x/resources/template/cdhx/cdh6xTemplate.json
@@ -412,6 +412,13 @@
 			"description": "",
 			"exclusions": [
 				{
+					"groupId": "org.apache.hive",
+					"artifactId": "hive-exec",
+					"classifier": "",
+					"extension": "",
+					"description": ""
+				},
+				{
 					"groupId": "io.netty",
 					"artifactId": "*",
 					"classifier": "",
@@ -574,77 +581,12 @@
 		},
 		{
 			"id": "hive-exec",
-			"type": "BASE",
+			"type": "STANDARD",
 			"context": "{properties.context}",
-			"groupId": "org.apache.hive",
-			"artifactId": "hive-exec",
-			"classifier": "",
-			"description": "",
-			"exclusions": [
-				{
-					"groupId": "org.apache.curator",
-					"artifactId": "apache-curator",
-					"classifier": "",
-					"extension": "",
-					"description": ""
-				},
-				{
-					"groupId": "eigenbase",
-					"artifactId": "eigenbase-properties",
-					"classifier": "",
-					"extension": "",
-					"description": ""
-				},
-				{
-					"groupId": "org.pentaho",
-					"artifactId": "pentaho-aggdesigner-algorithm",
-					"classifier": "",
-					"extension": "",
-					"description": ""
-				},
-				{
-					"groupId": "xerces",
-					"artifactId": "*",
-					"classifier": "",
-					"extension": "",
-					"description": ""
-				},
-				{
-					"groupId": "org.apache.spark",
-					"artifactId": "spark-core_2.11",
-					"classifier": "",
-					"extension": "",
-					"description": ""
-				},
-				{
-					"groupId": "jdk.tools",
-					"artifactId": "*",
-					"classifier": "",
-					"extension": "",
-					"description": ""
-				},
-                {
-                    "groupId": "org.glassfish",
-                    "artifactId": "javax.el",
-                    "classifier": "",
-                    "extension": "",
-                    "description": ""
-                },
-				{
-					"groupId": "org.cloudera.logredactor",
-					"artifactId": "*",
-					"classifier": "",
-					"extension": "",
-					"description": ""
-				},
-                {
-                    "groupId": "org.apache.logging.log4j",
-                    "artifactId": "*",
-					"classifier": "",
-                    "extension": "",
-                    "description": ""
-                }
-			]
+			"jarName": "hive-exec-shade-2.1.1-cdh6.1.1.jar",
+			"mvnUri": "mvn:org.talend.libraries/hive-exec-shade-2.1.1-cdh6.1.1/6.0.0",
+			"useStudioRepository": "true",
+			"description": ""
 		},
 		{
 			"id": "hive-hbase-handler",
@@ -655,6 +597,13 @@
 			"classifier": "",
 			"description": "",
 			"exclusions": [
+				{
+					"groupId": "org.apache.hive",
+					"artifactId": "hive-exec",
+					"classifier": "",
+					"extension": "",
+					"description": ""
+				},
 				{
 					"groupId": "eigenbase",
 					"artifactId": "eigenbase-properties",
@@ -794,6 +743,13 @@
 			"description": "",
 			"exclusions": [
 				{
+					"groupId": "org.apache.hive",
+					"artifactId": "hive-exec",
+					"classifier": "",
+					"extension": "",
+					"description": ""
+				},
+				{
 					"groupId": "org.apache.curator",
 					"artifactId": "apache-curator",
 					"classifier": "",
@@ -868,6 +824,13 @@
 			"description": "",
 			"exclusions": [
 				{
+					"groupId": "org.apache.hive",
+					"artifactId": "hive-exec",
+					"classifier": "",
+					"extension": "",
+					"description": ""
+				},
+				{
 					"groupId": "org.apache.curator",
 					"artifactId": "apache-curator",
 					"classifier": "",
@@ -934,6 +897,13 @@
 			"classifier": "",
 			"description": "",
 			"exclusions": [
+				{
+					"groupId": "org.apache.hive",
+					"artifactId": "hive-exec",
+					"classifier": "",
+					"extension": "",
+					"description": ""
+				},
 				{
 					"groupId": "org.apache.curator",
 					"artifactId": "apache-curator",
@@ -1432,6 +1402,13 @@
 			"classifier": "",
 			"description": "",
 			"exclusions": [
+				{
+					"groupId": "org.apache.hive",
+					"artifactId": "hive-exec",
+					"classifier": "",
+					"extension": "",
+					"description": ""
+				},
 				{
 					"groupId": "org.apache.curator",
 					"artifactId": "apache-curator",


### PR DESCRIPTION
forked hive repository from Cloudera
created a shaded jar for hive-exec (cdh6.1)
exclude hive-exec from dynamic distro
forced the usage of the shaded version
created a new built-in

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
