### PR TITLE
fix(TBD-9956):Sqoop issue with Java API/parquet format/HDP 2.6

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.hdpx/resources/builtin/hdpx/Hortonworks_HDP_2_6_0_3_8.json
+++ b/main/plugins/org.talend.hadoop.distribution.hdpx/resources/builtin/hdpx/Hortonworks_HDP_2_6_0_3_8.json
@@ -4,13 +4,10 @@
     "distribution" : "HORTONWORKS",
     "id" : "HDP_2_6_0_3_8",
     "name" : "Hortonworks Data Platform V2.6.0.3-8",
-    "projectTechnicalName" : "LOCAL_PROJECT",
     "repository" : "https://talend-update.talend.com/nexus/content/groups/dynamicdistribution/",
-    "selectedSparkVersions" : [ 
-    	"SPARK_2_1" 
-    ],
+    "selectedSparkVersions" : [ "SPARK_2_1" ],
     "tagName" : "dynamicPluginConfiguration",
-    "templateId" : "HDP2xxDistributionTemplate",    
+    "templateId" : "HDP2xxDistributionTemplate",
     "version" : "2.6.0.3-8"
   }, {
     "childNodes" : [ {
@@ -852,18 +849,6 @@
       "tagName" : "libraryNeededGroup",
       "templateId" : "HDFS-LIB-DYNAMIC"
     }, {
-          "childNodes": [
-            {
-              "childNodes": [],
-              "id": "DYNAMIC_HDP_2_6_0_3_8_jackson_databind_2_6_6_jar",
-              "tagName": "library"
-            }
-          ],
-          "description": "Hdfs libraries for every execution engine except Spark 1.6",
-          "id": "DYNAMIC_HDP_2_6_0_3_8_HDFS-NOT-SPARK-1-6_LIB_DYNAMIC",
-          "tagName": "libraryNeededGroup",
-          "templateId": "HDFS-NOT-SPARK-1-6-LIB-DYNAMIC"
-        }, {
       "childNodes" : [ {
         "childNodes" : [ ],
         "id" : "DYNAMIC_HDP_2_6_0_3_8_HikariCP_2_5_1_jar",
@@ -1722,7 +1707,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_HikariCP_2_5_1_jar",
-      "mvn_uri" : "mvn:com.zaxxer/HikariCP/2.5.1",
+      "mvn_uri" : "mvn:com.zaxxer/HikariCP/2.5.1/jar",
       "name" : "HikariCP-2.5.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -1736,7 +1721,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_JavaEWAH_0_3_2_jar",
-      "mvn_uri" : "mvn:com.googlecode.javaewah/JavaEWAH/0.3.2",
+      "mvn_uri" : "mvn:com.googlecode.javaewah/JavaEWAH/0.3.2/jar",
       "name" : "JavaEWAH-0.3.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -4578,7 +4563,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_RoaringBitmap_0_5_11_jar",
-      "mvn_uri" : "mvn:org.roaringbitmap/RoaringBitmap/0.5.11",
+      "mvn_uri" : "mvn:org.roaringbitmap/RoaringBitmap/0.5.11/jar",
       "name" : "RoaringBitmap-0.5.11.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -6418,6 +6403,10 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
+        "id" : "DYNAMIC_HDP_2_6_0_3_8_fastutil_6_5_7_jar",
+        "tagName" : "library"
+      }, {
+        "childNodes" : [ ],
         "id" : "DYNAMIC_HDP_2_6_0_3_8_hsqldb_1_8_0_10_jar",
         "tagName" : "library"
       }, {
@@ -6454,11 +6443,15 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_HDP_2_6_0_3_8_parquet_column_1_8_2_jar",
+        "id" : "DYNAMIC_HDP_2_6_0_3_8_parquet_avro_1_4_1",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
         "id" : "DYNAMIC_HDP_2_6_0_3_8_parquet_avro_1_8_2_jar",
+        "tagName" : "library"
+      }, {
+        "childNodes" : [ ],
+        "id" : "DYNAMIC_HDP_2_6_0_3_8_parquet_column_1_8_2_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -6518,7 +6511,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_ST4_4_0_4_jar",
-      "mvn_uri" : "mvn:org.antlr/ST4/4.0.4",
+      "mvn_uri" : "mvn:org.antlr/ST4/4.0.4/jar",
       "name" : "ST4-4.0.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -6919,19 +6912,7 @@
       "id" : "DYNAMIC_HDP_2_6_0_3_8_TEZ_LIB_DYNAMIC",
       "tagName" : "libraryNeededGroup",
       "templateId" : "TEZ-LIB-DYNAMIC"
-     }, {
-          "childNodes": [
-            {
-              "childNodes": [],
-              "id": "DYNAMIC_HDP_2_6_0_3_8_jackson_databind_2_6_6_jar",
-              "tagName": "library"
-            }
-          ],
-          "description": "Tez libraries for all execution engines except Spark 1.6",
-          "id": "DYNAMIC_HDP_2_6_0_3_8_TEZ-NOT-SPARK-1-6-LIB-DYNAMIC",
-          "tagName": "libraryNeededGroup",
-          "templateId": "TEZ-NOT-SPARK-1-6-LIB-DYNAMIC"
-      }, {
+    }, {
       "childNodes" : [ {
         "childNodes" : [ ],
         "id" : "DYNAMIC_HDP_2_6_0_3_8_activation_1_1_jar",
@@ -7158,6 +7139,10 @@
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
+        "id" : "DYNAMIC_HDP_2_6_0_3_8_jackson_databind_2_6_6_jar",
+        "tagName" : "library"
+      }, {
+        "childNodes" : [ ],
         "id" : "DYNAMIC_HDP_2_6_0_3_8_jackson_jaxrs_1_9_13_jar",
         "tagName" : "library"
       }, {
@@ -7330,7 +7315,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_activation_1_1_jar",
-      "mvn_uri" : "mvn:javax.activation/activation/1.1",
+      "mvn_uri" : "mvn:javax.activation/activation/1.1/jar",
       "name" : "activation-1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7338,7 +7323,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_akka_actor_2_10_2_3_4_spark_jar",
-      "mvn_uri" : "mvn:org.spark-project.akka/akka-actor_2.10/2.3.4-spark",
+      "mvn_uri" : "mvn:org.spark-project.akka/akka-actor_2.10/2.3.4-spark/jar",
       "name" : "akka-actor_2.10-2.3.4-spark.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7346,7 +7331,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_akka_remote_2_10_2_3_4_spark_jar",
-      "mvn_uri" : "mvn:org.spark-project.akka/akka-remote_2.10/2.3.4-spark",
+      "mvn_uri" : "mvn:org.spark-project.akka/akka-remote_2.10/2.3.4-spark/jar",
       "name" : "akka-remote_2.10-2.3.4-spark.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7354,7 +7339,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_akka_slf4j_2_10_2_3_4_spark_jar",
-      "mvn_uri" : "mvn:org.spark-project.akka/akka-slf4j_2.10/2.3.4-spark",
+      "mvn_uri" : "mvn:org.spark-project.akka/akka-slf4j_2.10/2.3.4-spark/jar",
       "name" : "akka-slf4j_2.10-2.3.4-spark.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7370,7 +7355,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_ant_1_6_5_jar",
-      "mvn_uri" : "mvn:ant/ant/1.6.5",
+      "mvn_uri" : "mvn:ant/ant/1.6.5/jar",
       "name" : "ant-1.6.5.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7378,7 +7363,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_ant_1_9_1_jar",
-      "mvn_uri" : "mvn:org.apache.ant/ant/1.9.1",
+      "mvn_uri" : "mvn:org.apache.ant/ant/1.9.1/jar",
       "name" : "ant-1.9.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7386,7 +7371,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_ant_launcher_1_9_1_jar",
-      "mvn_uri" : "mvn:org.apache.ant/ant-launcher/1.9.1",
+      "mvn_uri" : "mvn:org.apache.ant/ant-launcher/1.9.1/jar",
       "name" : "ant-launcher-1.9.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7394,7 +7379,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_antlr4_runtime_4_5_3_jar",
-      "mvn_uri" : "mvn:org.antlr/antlr4-runtime/4.5.3",
+      "mvn_uri" : "mvn:org.antlr/antlr4-runtime/4.5.3/jar",
       "name" : "antlr4-runtime-4.5.3.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7402,7 +7387,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_antlr_2_7_7_jar",
-      "mvn_uri" : "mvn:antlr/antlr/2.7.7",
+      "mvn_uri" : "mvn:antlr/antlr/2.7.7/jar",
       "name" : "antlr-2.7.7.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7410,7 +7395,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_antlr_runtime_3_4_jar",
-      "mvn_uri" : "mvn:org.antlr/antlr-runtime/3.4",
+      "mvn_uri" : "mvn:org.antlr/antlr-runtime/3.4/jar",
       "name" : "antlr-runtime-3.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7418,7 +7403,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_aopalliance_1_0_jar",
-      "mvn_uri" : "mvn:aopalliance/aopalliance/1.0",
+      "mvn_uri" : "mvn:aopalliance/aopalliance/1.0/jar",
       "name" : "aopalliance-1.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7426,7 +7411,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_aopalliance_repackaged_2_4_0_b34_jar",
-      "mvn_uri" : "mvn:org.glassfish.hk2.external/aopalliance-repackaged/2.4.0-b34",
+      "mvn_uri" : "mvn:org.glassfish.hk2.external/aopalliance-repackaged/2.4.0-b34/jar",
       "name" : "aopalliance-repackaged-2.4.0-b34.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7434,7 +7419,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_apache_log4j_extras_1_2_17_jar",
-      "mvn_uri" : "mvn:log4j/apache-log4j-extras/1.2.17",
+      "mvn_uri" : "mvn:log4j/apache-log4j-extras/1.2.17/jar",
       "name" : "apache-log4j-extras-1.2.17.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7442,7 +7427,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_apacheds_i18n_2_0_0_M15_jar",
-      "mvn_uri" : "mvn:org.apache.directory.server/apacheds-i18n/2.0.0-M15",
+      "mvn_uri" : "mvn:org.apache.directory.server/apacheds-i18n/2.0.0-M15/jar",
       "name" : "apacheds-i18n-2.0.0-M15.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7450,7 +7435,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_apacheds_kerberos_codec_2_0_0_M15_jar",
-      "mvn_uri" : "mvn:org.apache.directory.server/apacheds-kerberos-codec/2.0.0-M15",
+      "mvn_uri" : "mvn:org.apache.directory.server/apacheds-kerberos-codec/2.0.0-M15/jar",
       "name" : "apacheds-kerberos-codec-2.0.0-M15.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7458,7 +7443,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_api_asn1_api_1_0_0_M20_jar",
-      "mvn_uri" : "mvn:org.apache.directory.api/api-asn1-api/1.0.0-M20",
+      "mvn_uri" : "mvn:org.apache.directory.api/api-asn1-api/1.0.0-M20/jar",
       "name" : "api-asn1-api-1.0.0-M20.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7466,7 +7451,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_api_util_1_0_0_M20_jar",
-      "mvn_uri" : "mvn:org.apache.directory.api/api-util/1.0.0-M20",
+      "mvn_uri" : "mvn:org.apache.directory.api/api-util/1.0.0-M20/jar",
       "name" : "api-util-1.0.0-M20.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7474,7 +7459,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_arpack_combined_all_0_1_jar",
-      "mvn_uri" : "mvn:net.sourceforge.f2j/arpack_combined_all/0.1",
+      "mvn_uri" : "mvn:net.sourceforge.f2j/arpack_combined_all/0.1/jar",
       "name" : "arpack_combined_all-0.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7482,7 +7467,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_asm_3_2_jar",
-      "mvn_uri" : "mvn:asm/asm/3.2",
+      "mvn_uri" : "mvn:asm/asm/3.2/jar",
       "name" : "asm-3.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7490,7 +7475,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_asm_commons_3_1_jar",
-      "mvn_uri" : "mvn:asm/asm-commons/3.1",
+      "mvn_uri" : "mvn:asm/asm-commons/3.1/jar",
       "name" : "asm-commons-3.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7498,7 +7483,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_asm_tree_3_1_jar",
-      "mvn_uri" : "mvn:asm/asm-tree/3.1",
+      "mvn_uri" : "mvn:asm/asm-tree/3.1/jar",
       "name" : "asm-tree-3.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7542,7 +7527,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_automaton_1_11_8_jar",
-      "mvn_uri" : "mvn:dk.brics.automaton/automaton/1.11-8",
+      "mvn_uri" : "mvn:dk.brics.automaton/automaton/1.11-8/jar",
       "name" : "automaton-1.11-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7550,7 +7535,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_avatica_1_8_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.calcite.avatica/avatica/1.8.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.calcite.avatica/avatica/1.8.0.2.6.0.3-8/jar",
       "name" : "avatica-1.8.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7558,7 +7543,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_avatica_metrics_1_8_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.calcite.avatica/avatica-metrics/1.8.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.calcite.avatica/avatica-metrics/1.8.0.2.6.0.3-8/jar",
       "name" : "avatica-metrics-1.8.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7575,7 +7560,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_avro_1_8_2_jar",
-      "mvn_uri" : "mvn:org.apache.avro/avro/1.8.2",
+      "mvn_uri" : "mvn:org.apache.avro/avro/1.8.2/jar",
       "name" : "avro-1.8.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7583,7 +7568,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_avro_ipc_1_7_7_tests_jar",
-      "mvn_uri" : "mvn:org.apache.avro/avro-ipc/1.7.7/tests",
+      "mvn_uri" : "mvn:org.apache.avro/avro-ipc/1.7.7/jar/tests",
       "name" : "avro-ipc-1.7.7-tests.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7591,7 +7576,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_avro_ipc_1_8_2_jar",
-      "mvn_uri" : "mvn:org.apache.avro/avro-ipc/1.8.2",
+      "mvn_uri" : "mvn:org.apache.avro/avro-ipc/1.8.2/jar",
       "name" : "avro-ipc-1.8.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7599,7 +7584,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_avro_mapred_1_7_7_hadoop2_jar",
-      "mvn_uri" : "mvn:org.apache.avro/avro-mapred/1.7.7/hadoop2",
+      "mvn_uri" : "mvn:org.apache.avro/avro-mapred/1.7.7/jar/hadoop2",
       "name" : "avro-mapred-1.7.7-hadoop2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7615,7 +7600,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_aws_java_sdk_cloudwatch_1_10_61_jar",
-      "mvn_uri" : "mvn:com.amazonaws/aws-java-sdk-cloudwatch/1.10.61",
+      "mvn_uri" : "mvn:com.amazonaws/aws-java-sdk-cloudwatch/1.10.61/jar",
       "name" : "aws-java-sdk-cloudwatch-1.10.61.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7623,7 +7608,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_aws_java_sdk_core_1_11_160_jar",
-      "mvn_uri" : "mvn:com.amazonaws/aws-java-sdk-core/1.11.160",
+      "mvn_uri" : "mvn:com.amazonaws/aws-java-sdk-core/1.11.160/jar",
       "name" : "aws-java-sdk-core-1.11.160.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7639,7 +7624,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_aws_java_sdk_kinesis_1_10_61_jar",
-      "mvn_uri" : "mvn:com.amazonaws/aws-java-sdk-kinesis/1.10.61",
+      "mvn_uri" : "mvn:com.amazonaws/aws-java-sdk-kinesis/1.10.61/jar",
       "name" : "aws-java-sdk-kinesis-1.10.61.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7647,7 +7632,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_aws_java_sdk_kms_1_11_160_jar",
-      "mvn_uri" : "mvn:com.amazonaws/aws-java-sdk-kms/1.11.160",
+      "mvn_uri" : "mvn:com.amazonaws/aws-java-sdk-kms/1.11.160/jar",
       "name" : "aws-java-sdk-kms-1.11.160.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7655,7 +7640,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_aws_java_sdk_s3_1_11_160_jar",
-      "mvn_uri" : "mvn:com.amazonaws/aws-java-sdk-s3/1.11.160",
+      "mvn_uri" : "mvn:com.amazonaws/aws-java-sdk-s3/1.11.160/jar",
       "name" : "aws-java-sdk-s3-1.11.160.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7663,7 +7648,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_azure_data_lake_store_sdk_2_1_4_jar",
-      "mvn_uri" : "mvn:com.microsoft.azure/azure-data-lake-store-sdk/2.1.4",
+      "mvn_uri" : "mvn:com.microsoft.azure/azure-data-lake-store-sdk/2.1.4/jar",
       "name" : "azure-data-lake-store-sdk-2.1.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7671,7 +7656,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_azure_keyvault_core_0_8_0_jar",
-      "mvn_uri" : "mvn:com.microsoft.azure/azure-keyvault-core/0.8.0",
+      "mvn_uri" : "mvn:com.microsoft.azure/azure-keyvault-core/0.8.0/jar",
       "name" : "azure-keyvault-core-0.8.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7679,7 +7664,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_azure_storage_4_2_0_jar",
-      "mvn_uri" : "mvn:com.microsoft.azure/azure-storage/4.2.0",
+      "mvn_uri" : "mvn:com.microsoft.azure/azure-storage/4.2.0/jar",
       "name" : "azure-storage-4.2.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7687,7 +7672,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_bonecp_0_8_0_RELEASE_jar",
-      "mvn_uri" : "mvn:com.jolbox/bonecp/0.8.0.RELEASE",
+      "mvn_uri" : "mvn:com.jolbox/bonecp/0.8.0.RELEASE/jar",
       "name" : "bonecp-0.8.0.RELEASE.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7695,7 +7680,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_breeze_2_11_0_12_jar",
-      "mvn_uri" : "mvn:org.scalanlp/breeze_2.11/0.12",
+      "mvn_uri" : "mvn:org.scalanlp/breeze_2.11/0.12/jar",
       "name" : "breeze_2.11-0.12.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7703,7 +7688,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_breeze_macros_2_11_0_12_jar",
-      "mvn_uri" : "mvn:org.scalanlp/breeze-macros_2.11/0.12",
+      "mvn_uri" : "mvn:org.scalanlp/breeze-macros_2.11/0.12/jar",
       "name" : "breeze-macros_2.11-0.12.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7711,7 +7696,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_calcite_avatica_1_2_0_incubating_jar",
-      "mvn_uri" : "mvn:org.apache.calcite/calcite-avatica/1.2.0-incubating",
+      "mvn_uri" : "mvn:org.apache.calcite/calcite-avatica/1.2.0-incubating/jar",
       "name" : "calcite-avatica-1.2.0-incubating.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7719,7 +7704,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_calcite_core_1_2_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.calcite/calcite-core/1.2.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.calcite/calcite-core/1.2.0.2.6.0.3-8/jar",
       "name" : "calcite-core-1.2.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7727,7 +7712,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_calcite_linq4j_1_2_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.calcite/calcite-linq4j/1.2.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.calcite/calcite-linq4j/1.2.0.2.6.0.3-8/jar",
       "name" : "calcite-linq4j-1.2.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7735,7 +7720,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_chill_2_10_0_5_0_jar",
-      "mvn_uri" : "mvn:com.twitter/chill_2.10/0.5.0",
+      "mvn_uri" : "mvn:com.twitter/chill_2.10/0.5.0/jar",
       "name" : "chill_2.10-0.5.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7743,7 +7728,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_chill_2_11_0_8_0_jar",
-      "mvn_uri" : "mvn:com.twitter/chill_2.11/0.8.0",
+      "mvn_uri" : "mvn:com.twitter/chill_2.11/0.8.0/jar",
       "name" : "chill_2.11-0.8.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7751,7 +7736,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_chill_java_0_8_0_jar",
-      "mvn_uri" : "mvn:com.twitter/chill-java/0.8.0",
+      "mvn_uri" : "mvn:com.twitter/chill-java/0.8.0/jar",
       "name" : "chill-java-0.8.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7759,7 +7744,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_beanutils_1_7_0_jar",
-      "mvn_uri" : "mvn:commons-beanutils/commons-beanutils/1.7.0",
+      "mvn_uri" : "mvn:commons-beanutils/commons-beanutils/1.7.0/jar",
       "name" : "commons-beanutils-1.7.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7767,7 +7752,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_beanutils_core_1_8_0_jar",
-      "mvn_uri" : "mvn:commons-beanutils/commons-beanutils-core/1.8.0",
+      "mvn_uri" : "mvn:commons-beanutils/commons-beanutils-core/1.8.0/jar",
       "name" : "commons-beanutils-core-1.8.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7775,7 +7760,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_cli_1_2_jar",
-      "mvn_uri" : "mvn:commons-cli/commons-cli/1.2",
+      "mvn_uri" : "mvn:commons-cli/commons-cli/1.2/jar",
       "name" : "commons-cli-1.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7783,7 +7768,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_codec_1_10_jar",
-      "mvn_uri" : "mvn:commons-codec/commons-codec/1.10",
+      "mvn_uri" : "mvn:commons-codec/commons-codec/1.10/jar",
       "name" : "commons-codec-1.10.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7800,7 +7785,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_collections4_4_1_jar",
-      "mvn_uri" : "mvn:org.apache.commons/commons-collections4/4.1",
+      "mvn_uri" : "mvn:org.apache.commons/commons-collections4/4.1/jar",
       "name" : "commons-collections4-4.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7808,7 +7793,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_collections_3_2_2_jar",
-      "mvn_uri" : "mvn:commons-collections/commons-collections/3.2.2",
+      "mvn_uri" : "mvn:commons-collections/commons-collections/3.2.2/jar",
       "name" : "commons-collections-3.2.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7816,7 +7801,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_compiler_3_0_0_jar",
-      "mvn_uri" : "mvn:org.codehaus.janino/commons-compiler/3.0.0",
+      "mvn_uri" : "mvn:org.codehaus.janino/commons-compiler/3.0.0/jar",
       "name" : "commons-compiler-3.0.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7824,7 +7809,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_compress_1_8_1_jar",
-      "mvn_uri" : "mvn:org.apache.commons/commons-compress/1.8.1",
+      "mvn_uri" : "mvn:org.apache.commons/commons-compress/1.8.1/jar",
       "name" : "commons-compress-1.8.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7832,7 +7817,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_configuration_1_6_jar",
-      "mvn_uri" : "mvn:commons-configuration/commons-configuration/1.6",
+      "mvn_uri" : "mvn:commons-configuration/commons-configuration/1.6/jar",
       "name" : "commons-configuration-1.6.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7840,7 +7825,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_crypto_1_0_0_jar",
-      "mvn_uri" : "mvn:org.apache.commons/commons-crypto/1.0.0",
+      "mvn_uri" : "mvn:org.apache.commons/commons-crypto/1.0.0/jar",
       "name" : "commons-crypto-1.0.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7848,7 +7833,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_daemon_1_0_13_jar",
-      "mvn_uri" : "mvn:commons-daemon/commons-daemon/1.0.13",
+      "mvn_uri" : "mvn:commons-daemon/commons-daemon/1.0.13/jar",
       "name" : "commons-daemon-1.0.13.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7856,7 +7841,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_dbcp_1_4_jar",
-      "mvn_uri" : "mvn:commons-dbcp/commons-dbcp/1.4",
+      "mvn_uri" : "mvn:commons-dbcp/commons-dbcp/1.4/jar",
       "name" : "commons-dbcp-1.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7864,7 +7849,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_digester_1_8_jar",
-      "mvn_uri" : "mvn:commons-digester/commons-digester/1.8",
+      "mvn_uri" : "mvn:commons-digester/commons-digester/1.8/jar",
       "name" : "commons-digester-1.8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7872,7 +7857,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_el_1_0_jar",
-      "mvn_uri" : "mvn:commons-el/commons-el/1.0",
+      "mvn_uri" : "mvn:commons-el/commons-el/1.0/jar",
       "name" : "commons-el-1.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7880,7 +7865,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_httpclient_3_1_jar",
-      "mvn_uri" : "mvn:commons-httpclient/commons-httpclient/3.1",
+      "mvn_uri" : "mvn:commons-httpclient/commons-httpclient/3.1/jar",
       "name" : "commons-httpclient-3.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7888,7 +7873,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_io_2_4_jar",
-      "mvn_uri" : "mvn:commons-io/commons-io/2.4",
+      "mvn_uri" : "mvn:commons-io/commons-io/2.4/jar",
       "name" : "commons-io-2.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7896,7 +7881,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_lang3_3_5_jar",
-      "mvn_uri" : "mvn:org.apache.commons/commons-lang3/3.5",
+      "mvn_uri" : "mvn:org.apache.commons/commons-lang3/3.5/jar",
       "name" : "commons-lang3-3.5.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7904,7 +7889,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_lang_2_6_jar",
-      "mvn_uri" : "mvn:commons-lang/commons-lang/2.6",
+      "mvn_uri" : "mvn:commons-lang/commons-lang/2.6/jar",
       "name" : "commons-lang-2.6.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7921,7 +7906,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_logging_1_2_jar",
-      "mvn_uri" : "mvn:commons-logging/commons-logging/1.2",
+      "mvn_uri" : "mvn:commons-logging/commons-logging/1.2/jar",
       "name" : "commons-logging-1.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7929,7 +7914,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_math3_3_4_1_jar",
-      "mvn_uri" : "mvn:org.apache.commons/commons-math3/3.4.1",
+      "mvn_uri" : "mvn:org.apache.commons/commons-math3/3.4.1/jar",
       "name" : "commons-math3-3.4.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7937,7 +7922,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_math_2_2_jar",
-      "mvn_uri" : "mvn:org.apache.commons/commons-math/2.2",
+      "mvn_uri" : "mvn:org.apache.commons/commons-math/2.2/jar",
       "name" : "commons-math-2.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7945,7 +7930,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_net_3_1_jar",
-      "mvn_uri" : "mvn:commons-net/commons-net/3.1",
+      "mvn_uri" : "mvn:commons-net/commons-net/3.1/jar",
       "name" : "commons-net-3.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7953,7 +7938,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_commons_pool_1_5_4_jar",
-      "mvn_uri" : "mvn:commons-pool/commons-pool/1.5.4",
+      "mvn_uri" : "mvn:commons-pool/commons-pool/1.5.4/jar",
       "name" : "commons-pool-1.5.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7961,7 +7946,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_compress_lzf_1_0_3_jar",
-      "mvn_uri" : "mvn:com.ning/compress-lzf/1.0.3",
+      "mvn_uri" : "mvn:com.ning/compress-lzf/1.0.3/jar",
       "name" : "compress-lzf-1.0.3.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7978,7 +7963,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_config_1_2_1_jar",
-      "mvn_uri" : "mvn:com.typesafe/config/1.2.1",
+      "mvn_uri" : "mvn:com.typesafe/config/1.2.1/jar",
       "name" : "config-1.2.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7986,7 +7971,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_core_1_1_2_jar",
-      "mvn_uri" : "mvn:com.github.fommil.netlib/core/1.1.2",
+      "mvn_uri" : "mvn:com.github.fommil.netlib/core/1.1.2/jar",
       "name" : "core-1.1.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -7994,7 +7979,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_core_3_1_1_jar",
-      "mvn_uri" : "mvn:org.eclipse.jdt/core/3.1.1",
+      "mvn_uri" : "mvn:org.eclipse.jdt/core/3.1.1/jar",
       "name" : "core-3.1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8002,7 +7987,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_curator_client_2_7_1_jar",
-      "mvn_uri" : "mvn:org.apache.curator/curator-client/2.7.1",
+      "mvn_uri" : "mvn:org.apache.curator/curator-client/2.7.1/jar",
       "name" : "curator-client-2.7.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8010,7 +7995,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_curator_framework_2_7_1_jar",
-      "mvn_uri" : "mvn:org.apache.curator/curator-framework/2.7.1",
+      "mvn_uri" : "mvn:org.apache.curator/curator-framework/2.7.1/jar",
       "name" : "curator-framework-2.7.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8018,7 +8003,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_curator_recipes_2_7_1_jar",
-      "mvn_uri" : "mvn:org.apache.curator/curator-recipes/2.7.1",
+      "mvn_uri" : "mvn:org.apache.curator/curator-recipes/2.7.1/jar",
       "name" : "curator-recipes-2.7.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8026,7 +8011,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_datanucleus_api_jdo_4_2_1_jar",
-      "mvn_uri" : "mvn:org.datanucleus/datanucleus-api-jdo/4.2.1",
+      "mvn_uri" : "mvn:org.datanucleus/datanucleus-api-jdo/4.2.1/jar",
       "name" : "datanucleus-api-jdo-4.2.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8034,7 +8019,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_datanucleus_core_4_1_6_jar",
-      "mvn_uri" : "mvn:org.datanucleus/datanucleus-core/4.1.6",
+      "mvn_uri" : "mvn:org.datanucleus/datanucleus-core/4.1.6/jar",
       "name" : "datanucleus-core-4.1.6.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8042,7 +8027,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_datanucleus_rdbms_4_1_7_jar",
-      "mvn_uri" : "mvn:org.datanucleus/datanucleus-rdbms/4.1.7",
+      "mvn_uri" : "mvn:org.datanucleus/datanucleus-rdbms/4.1.7/jar",
       "name" : "datanucleus-rdbms-4.1.7.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8050,7 +8035,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_derby_10_12_1_1_jar",
-      "mvn_uri" : "mvn:org.apache.derby/derby/10.12.1.1",
+      "mvn_uri" : "mvn:org.apache.derby/derby/10.12.1.1/jar",
       "name" : "derby-10.12.1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8058,7 +8043,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_disruptor_3_3_0_jar",
-      "mvn_uri" : "mvn:com.lmax/disruptor/3.3.0",
+      "mvn_uri" : "mvn:com.lmax/disruptor/3.3.0/jar",
       "name" : "disruptor-3.3.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8066,7 +8051,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_dropwizard_metrics_hadoop_metrics2_reporter_0_1_2_jar",
-      "mvn_uri" : "mvn:com.github.joshelser/dropwizard-metrics-hadoop-metrics2-reporter/0.1.2",
+      "mvn_uri" : "mvn:com.github.joshelser/dropwizard-metrics-hadoop-metrics2-reporter/0.1.2/jar",
       "name" : "dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8074,7 +8059,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_eigenbase_properties_1_1_5_jar",
-      "mvn_uri" : "mvn:net.hydromatic/eigenbase-properties/1.1.5",
+      "mvn_uri" : "mvn:net.hydromatic/eigenbase-properties/1.1.5/jar",
       "name" : "eigenbase-properties-1.1.5.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8098,7 +8083,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_elephant_bird_hive_4_9_jar",
-      "mvn_uri" : "mvn:com.twitter.elephantbird/elephant-bird-hive/4.9",
+      "mvn_uri" : "mvn:com.twitter.elephantbird/elephant-bird-hive/4.9/jar",
       "name" : "elephant-bird-hive-4.9.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8106,7 +8091,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_elephant_bird_pig_4_9_jar",
-      "mvn_uri" : "mvn:com.twitter.elephantbird/elephant-bird-pig/4.9",
+      "mvn_uri" : "mvn:com.twitter.elephantbird/elephant-bird-pig/4.9/jar",
       "name" : "elephant-bird-pig-4.9.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8139,8 +8124,16 @@
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
+      "id" : "DYNAMIC_HDP_2_6_0_3_8_fastutil_6_5_7_jar",
+      "mvn_uri" : "mvn:it.unimi.dsi/fastutil/6.5.7/jar",
+      "name" : "fastutil-6.5.7.jar",
+      "tagName" : "libraryNeeded"
+    }, {
+      "childNodes" : [ ],
+      "context" : "plugin:org.talend.hadoop.distribution.hdpx",
+      "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_findbugs_annotations_1_3_9_1_jar",
-      "mvn_uri" : "mvn:com.github.stephenc.findbugs/findbugs-annotations/1.3.9-1",
+      "mvn_uri" : "mvn:com.github.stephenc.findbugs/findbugs-annotations/1.3.9-1/jar",
       "name" : "findbugs-annotations-1.3.9-1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8148,7 +8141,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_fst_2_24_jar",
-      "mvn_uri" : "mvn:de.ruedigermoeller/fst/2.24",
+      "mvn_uri" : "mvn:de.ruedigermoeller/fst/2.24/jar",
       "name" : "fst-2.24.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8156,7 +8149,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_geronimo_annotation_1_0_spec_1_1_1_jar",
-      "mvn_uri" : "mvn:org.apache.geronimo.specs/geronimo-annotation_1.0_spec/1.1.1",
+      "mvn_uri" : "mvn:org.apache.geronimo.specs/geronimo-annotation_1.0_spec/1.1.1/jar",
       "name" : "geronimo-annotation_1.0_spec-1.1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8164,7 +8157,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_geronimo_jaspic_1_0_spec_1_0_jar",
-      "mvn_uri" : "mvn:org.apache.geronimo.specs/geronimo-jaspic_1.0_spec/1.0",
+      "mvn_uri" : "mvn:org.apache.geronimo.specs/geronimo-jaspic_1.0_spec/1.0/jar",
       "name" : "geronimo-jaspic_1.0_spec-1.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8172,7 +8165,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_geronimo_jta_1_1_spec_1_1_1_jar",
-      "mvn_uri" : "mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1",
+      "mvn_uri" : "mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1/jar",
       "name" : "geronimo-jta_1.1_spec-1.1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8180,7 +8173,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_groovy_all_2_4_5_jar",
-      "mvn_uri" : "mvn:org.codehaus.groovy/groovy-all/2.4.5",
+      "mvn_uri" : "mvn:org.codehaus.groovy/groovy-all/2.4.5/jar",
       "name" : "groovy-all-2.4.5.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8188,7 +8181,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_gson_2_2_4_jar",
-      "mvn_uri" : "mvn:com.google.code.gson/gson/2.2.4",
+      "mvn_uri" : "mvn:com.google.code.gson/gson/2.2.4/jar",
       "name" : "gson-2.2.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8205,7 +8198,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_guava_18_0_jar",
-      "mvn_uri" : "mvn:com.google.guava/guava/18.0",
+      "mvn_uri" : "mvn:com.google.guava/guava/18.0/jar",
       "name" : "guava-18.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8213,7 +8206,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_guice_3_0_jar",
-      "mvn_uri" : "mvn:com.google.inject/guice/3.0",
+      "mvn_uri" : "mvn:com.google.inject/guice/3.0/jar",
       "name" : "guice-3.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8230,7 +8223,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_guice_servlet_3_0_jar",
-      "mvn_uri" : "mvn:com.google.inject.extensions/guice-servlet/3.0",
+      "mvn_uri" : "mvn:com.google.inject.extensions/guice-servlet/3.0/jar",
       "name" : "guice-servlet-3.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8247,7 +8240,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_annotations_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-annotations/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-annotations/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-annotations-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8255,7 +8248,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_archives_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-archives/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-archives/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-archives-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8263,7 +8256,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_auth_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-auth/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-auth/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-auth-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8312,7 +8305,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_common_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-common/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-common/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-common-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8320,7 +8313,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_distcp_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-distcp/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-distcp/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-distcp-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8328,7 +8321,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_hdfs_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-hdfs/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-hdfs/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-hdfs-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8336,7 +8329,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_mapreduce_client_app_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-mapreduce-client-app/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-mapreduce-client-app/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-mapreduce-client-app-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8344,7 +8337,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_mapreduce_client_common_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-mapreduce-client-common/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-mapreduce-client-common/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-mapreduce-client-common-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8352,7 +8345,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_mapreduce_client_core_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-mapreduce-client-core/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-mapreduce-client-core/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-mapreduce-client-core-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8360,7 +8353,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_mapreduce_client_jobclient_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-mapreduce-client-jobclient-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8368,7 +8361,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_mapreduce_client_shuffle_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-mapreduce-client-shuffle-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8376,7 +8369,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_yarn_api_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-api/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-api/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-yarn-api-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8384,7 +8377,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_yarn_client_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-client/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-client/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-yarn-client-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8392,7 +8385,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_yarn_common_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-common/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-common/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-yarn-common-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8400,7 +8393,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_yarn_registry_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-registry/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-registry/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-yarn-registry-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8408,7 +8401,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_yarn_server_applicationhistoryservice_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-server-applicationhistoryservice/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-server-applicationhistoryservice/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-yarn-server-applicationhistoryservice-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8416,7 +8409,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_yarn_server_common_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-server-common/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-server-common/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-yarn-server-common-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8424,7 +8417,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_yarn_server_resourcemanager_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-server-resourcemanager/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-server-resourcemanager/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-yarn-server-resourcemanager-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8432,7 +8425,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hadoop_yarn_server_web_proxy_2_7_3_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-server-web-proxy/2.7.3.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hadoop/hadoop-yarn-server-web-proxy/2.7.3.2.6.0.3-8/jar",
       "name" : "hadoop-yarn-server-web-proxy-2.7.3.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8440,7 +8433,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hamcrest_core_1_3_jar",
-      "mvn_uri" : "mvn:org.hamcrest/hamcrest-core/1.3",
+      "mvn_uri" : "mvn:org.hamcrest/hamcrest-core/1.3/jar",
       "name" : "hamcrest-core-1.3.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8448,7 +8441,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hbase_annotations_1_1_2_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hbase/hbase-annotations/1.1.2.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hbase/hbase-annotations/1.1.2.2.6.0.3-8/jar",
       "name" : "hbase-annotations-1.1.2.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8464,7 +8457,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hbase_common_1_1_2_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hbase/hbase-common/1.1.2.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hbase/hbase-common/1.1.2.2.6.0.3-8/jar",
       "name" : "hbase-common-1.1.2.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8472,7 +8465,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hbase_common_1_1_2_2_6_0_3_8_tests_jar",
-      "mvn_uri" : "mvn:org.apache.hbase/hbase-common/1.1.2.2.6.0.3-8/tests",
+      "mvn_uri" : "mvn:org.apache.hbase/hbase-common/1.1.2.2.6.0.3-8/jar/tests",
       "name" : "hbase-common-1.1.2.2.6.0.3-8-tests.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8480,7 +8473,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hbase_hadoop2_compat_1_1_2_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hbase/hbase-hadoop2-compat/1.1.2.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hbase/hbase-hadoop2-compat/1.1.2.2.6.0.3-8/jar",
       "name" : "hbase-hadoop2-compat-1.1.2.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8496,7 +8489,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hbase_prefix_tree_1_1_2_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hbase/hbase-prefix-tree/1.1.2.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hbase/hbase-prefix-tree/1.1.2.2.6.0.3-8/jar",
       "name" : "hbase-prefix-tree-1.1.2.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8504,7 +8497,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hbase_procedure_1_1_2_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hbase/hbase-procedure/1.1.2.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hbase/hbase-procedure/1.1.2.2.6.0.3-8/jar",
       "name" : "hbase-procedure-1.1.2.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8512,7 +8505,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hbase_protocol_1_1_2_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hbase/hbase-protocol/1.1.2.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hbase/hbase-protocol/1.1.2.2.6.0.3-8/jar",
       "name" : "hbase-protocol-1.1.2.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8520,7 +8513,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hbase_resource_bundle_1_1_2_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hbase/hbase-resource-bundle/1.1.2.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hbase/hbase-resource-bundle/1.1.2.2.6.0.3-8/jar",
       "name" : "hbase-resource-bundle-1.1.2.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8536,7 +8529,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_ant_1_2_1000_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hive/hive-ant/1.2.1000.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hive/hive-ant/1.2.1000.2.6.0.3-8/jar",
       "name" : "hive-ant-1.2.1000.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8544,7 +8537,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_cli_1_2_1000_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hive/hive-cli/1.2.1000.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hive/hive-cli/1.2.1000.2.6.0.3-8/jar",
       "name" : "hive-cli-1.2.1000.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8552,7 +8545,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_common_1_2_1000_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hive/hive-common/1.2.1000.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hive/hive-common/1.2.1000.2.6.0.3-8/jar",
       "name" : "hive-common-1.2.1000.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8560,7 +8553,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_exec_1_2_1000_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hive/hive-exec/1.2.1000.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hive/hive-exec/1.2.1000.2.6.0.3-8/jar",
       "name" : "hive-exec-1.2.1000.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8568,7 +8561,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_exec_1_2_1_spark2_hdp_jar",
-      "mvn_uri" : "mvn:org.spark-project.hive/hive-exec/1.2.1.spark2.hdp",
+      "mvn_uri" : "mvn:org.spark-project.hive/hive-exec/1.2.1.spark2.hdp/jar",
       "name" : "hive-exec-1.2.1.spark2.hdp.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8576,7 +8569,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_hcatalog_core_1_2_1000_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hive.hcatalog/hive-hcatalog-core/1.2.1000.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hive.hcatalog/hive-hcatalog-core/1.2.1000.2.6.0.3-8/jar",
       "name" : "hive-hcatalog-core-1.2.1000.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8608,7 +8601,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_metastore_1_2_1000_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hive/hive-metastore/1.2.1000.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hive/hive-metastore/1.2.1000.2.6.0.3-8/jar",
       "name" : "hive-metastore-1.2.1000.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8616,7 +8609,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_metastore_1_2_1_spark2_hdp_jar",
-      "mvn_uri" : "mvn:org.spark-project.hive/hive-metastore/1.2.1.spark2.hdp",
+      "mvn_uri" : "mvn:org.spark-project.hive/hive-metastore/1.2.1.spark2.hdp/jar",
       "name" : "hive-metastore-1.2.1.spark2.hdp.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8624,7 +8617,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_serde_1_2_1000_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hive/hive-serde/1.2.1000.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hive/hive-serde/1.2.1000.2.6.0.3-8/jar",
       "name" : "hive-serde-1.2.1000.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8632,7 +8625,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_service_1_2_1000_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hive/hive-service/1.2.1000.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hive/hive-service/1.2.1000.2.6.0.3-8/jar",
       "name" : "hive-service-1.2.1000.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8640,7 +8633,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_shims_0_20S_1_2_1000_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hive.shims/hive-shims-0.20S/1.2.1000.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hive.shims/hive-shims-0.20S/1.2.1000.2.6.0.3-8/jar",
       "name" : "hive-shims-0.20S-1.2.1000.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8648,7 +8641,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_shims_0_23_1_2_1000_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hive.shims/hive-shims-0.23/1.2.1000.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hive.shims/hive-shims-0.23/1.2.1000.2.6.0.3-8/jar",
       "name" : "hive-shims-0.23-1.2.1000.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8656,7 +8649,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_shims_1_2_1000_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hive/hive-shims/1.2.1000.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hive/hive-shims/1.2.1000.2.6.0.3-8/jar",
       "name" : "hive-shims-1.2.1000.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8664,7 +8657,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_shims_common_1_2_1000_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hive.shims/hive-shims-common/1.2.1000.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hive.shims/hive-shims-common/1.2.1000.2.6.0.3-8/jar",
       "name" : "hive-shims-common-1.2.1000.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8672,7 +8665,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hive_shims_scheduler_1_2_1000_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.hive.shims/hive-shims-scheduler/1.2.1000.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.hive.shims/hive-shims-scheduler/1.2.1000.2.6.0.3-8/jar",
       "name" : "hive-shims-scheduler-1.2.1000.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8680,7 +8673,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hk2_api_2_4_0_b34_jar",
-      "mvn_uri" : "mvn:org.glassfish.hk2/hk2-api/2.4.0-b34",
+      "mvn_uri" : "mvn:org.glassfish.hk2/hk2-api/2.4.0-b34/jar",
       "name" : "hk2-api-2.4.0-b34.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8688,7 +8681,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hk2_locator_2_4_0_b34_jar",
-      "mvn_uri" : "mvn:org.glassfish.hk2/hk2-locator/2.4.0-b34",
+      "mvn_uri" : "mvn:org.glassfish.hk2/hk2-locator/2.4.0-b34/jar",
       "name" : "hk2-locator-2.4.0-b34.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8696,7 +8689,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hk2_utils_2_4_0_b34_jar",
-      "mvn_uri" : "mvn:org.glassfish.hk2/hk2-utils/2.4.0-b34",
+      "mvn_uri" : "mvn:org.glassfish.hk2/hk2-utils/2.4.0-b34/jar",
       "name" : "hk2-utils-2.4.0-b34.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8704,7 +8697,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_hsqldb_1_8_0_10_jar",
-      "mvn_uri" : "mvn:hsqldb/hsqldb/1.8.0.10",
+      "mvn_uri" : "mvn:hsqldb/hsqldb/1.8.0.10/jar",
       "name" : "hsqldb-1.8.0.10.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8712,7 +8705,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_htrace_core_3_1_0_incubating_jar",
-      "mvn_uri" : "mvn:org.apache.htrace/htrace-core/3.1.0-incubating",
+      "mvn_uri" : "mvn:org.apache.htrace/htrace-core/3.1.0-incubating/jar",
       "name" : "htrace-core-3.1.0-incubating.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8729,7 +8722,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_httpclient_4_5_2_jar",
-      "mvn_uri" : "mvn:org.apache.httpcomponents/httpclient/4.5.2",
+      "mvn_uri" : "mvn:org.apache.httpcomponents/httpclient/4.5.2/jar",
       "name" : "httpclient-4.5.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8746,7 +8739,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_httpcore_4_4_4_jar",
-      "mvn_uri" : "mvn:org.apache.httpcomponents/httpcore/4.4.4",
+      "mvn_uri" : "mvn:org.apache.httpcomponents/httpcore/4.4.4/jar",
       "name" : "httpcore-4.4.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8754,7 +8747,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_httpdlog_inputformat_2_4_jar",
-      "mvn_uri" : "mvn:nl.basjes.parse.httpdlog/httpdlog-inputformat/2.4",
+      "mvn_uri" : "mvn:nl.basjes.parse.httpdlog/httpdlog-inputformat/2.4/jar",
       "name" : "httpdlog-inputformat-2.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8762,7 +8755,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_httpdlog_parser_2_4_jar",
-      "mvn_uri" : "mvn:nl.basjes.parse.httpdlog/httpdlog-parser/2.4",
+      "mvn_uri" : "mvn:nl.basjes.parse.httpdlog/httpdlog-parser/2.4/jar",
       "name" : "httpdlog-parser-2.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8770,7 +8763,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_httpdlog_pigloader_2_4_jar",
-      "mvn_uri" : "mvn:nl.basjes.parse.httpdlog/httpdlog-pigloader/2.4",
+      "mvn_uri" : "mvn:nl.basjes.parse.httpdlog/httpdlog-pigloader/2.4/jar",
       "name" : "httpdlog-pigloader-2.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8778,7 +8771,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_ion_java_1_0_2_jar",
-      "mvn_uri" : "mvn:software.amazon.ion/ion-java/1.0.2",
+      "mvn_uri" : "mvn:software.amazon.ion/ion-java/1.0.2/jar",
       "name" : "ion-java-1.0.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8786,7 +8779,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_ivy_2_4_0_jar",
-      "mvn_uri" : "mvn:org.apache.ivy/ivy/2.4.0",
+      "mvn_uri" : "mvn:org.apache.ivy/ivy/2.4.0/jar",
       "name" : "ivy-2.4.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8794,7 +8787,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jackson_annotations_2_6_5_jar",
-      "mvn_uri" : "mvn:com.fasterxml.jackson.core/jackson-annotations/2.6.5",
+      "mvn_uri" : "mvn:com.fasterxml.jackson.core/jackson-annotations/2.6.5/jar",
       "name" : "jackson-annotations-2.6.5.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8802,7 +8795,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jackson_core_2_6_6_jar",
-      "mvn_uri" : "mvn:com.fasterxml.jackson.core/jackson-core/2.6.6",
+      "mvn_uri" : "mvn:com.fasterxml.jackson.core/jackson-core/2.6.6/jar",
       "name" : "jackson-core-2.6.6.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8810,7 +8803,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jackson_core_asl_1_9_13_jar",
-      "mvn_uri" : "mvn:org.codehaus.jackson/jackson-core-asl/1.9.13",
+      "mvn_uri" : "mvn:org.codehaus.jackson/jackson-core-asl/1.9.13/jar",
       "name" : "jackson-core-asl-1.9.13.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8818,7 +8811,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jackson_databind_2_6_6_jar",
-      "mvn_uri" : "mvn:com.fasterxml.jackson.core/jackson-databind/2.6.6",
+      "mvn_uri" : "mvn:com.fasterxml.jackson.core/jackson-databind/2.6.6/jar",
       "name" : "jackson-databind-2.6.6.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8826,7 +8819,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jackson_dataformat_cbor_2_6_6_jar",
-      "mvn_uri" : "mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.6.6",
+      "mvn_uri" : "mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.6.6/jar",
       "name" : "jackson-dataformat-cbor-2.6.6.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8834,7 +8827,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jackson_jaxrs_1_9_13_jar",
-      "mvn_uri" : "mvn:org.codehaus.jackson/jackson-jaxrs/1.9.13",
+      "mvn_uri" : "mvn:org.codehaus.jackson/jackson-jaxrs/1.9.13/jar",
       "name" : "jackson-jaxrs-1.9.13.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8842,7 +8835,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jackson_mapper_asl_1_9_13_jar",
-      "mvn_uri" : "mvn:org.codehaus.jackson/jackson-mapper-asl/1.9.13",
+      "mvn_uri" : "mvn:org.codehaus.jackson/jackson-mapper-asl/1.9.13/jar",
       "name" : "jackson-mapper-asl-1.9.13.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8850,7 +8843,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jackson_module_paranamer_2_6_5_jar",
-      "mvn_uri" : "mvn:com.fasterxml.jackson.module/jackson-module-paranamer/2.6.5",
+      "mvn_uri" : "mvn:com.fasterxml.jackson.module/jackson-module-paranamer/2.6.5/jar",
       "name" : "jackson-module-paranamer-2.6.5.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8858,7 +8851,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jackson_module_scala_2_10_2_4_4_jar",
-      "mvn_uri" : "mvn:com.fasterxml.jackson.module/jackson-module-scala_2.10/2.4.4",
+      "mvn_uri" : "mvn:com.fasterxml.jackson.module/jackson-module-scala_2.10/2.4.4/jar",
       "name" : "jackson-module-scala_2.10-2.4.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8866,7 +8859,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jackson_module_scala_2_11_2_6_5_jar",
-      "mvn_uri" : "mvn:com.fasterxml.jackson.module/jackson-module-scala_2.11/2.6.5",
+      "mvn_uri" : "mvn:com.fasterxml.jackson.module/jackson-module-scala_2.11/2.6.5/jar",
       "name" : "jackson-module-scala_2.11-2.6.5.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8874,7 +8867,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jackson_xc_1_9_13_jar",
-      "mvn_uri" : "mvn:org.codehaus.jackson/jackson-xc/1.9.13",
+      "mvn_uri" : "mvn:org.codehaus.jackson/jackson-xc/1.9.13/jar",
       "name" : "jackson-xc-1.9.13.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8882,7 +8875,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jamon_runtime_2_4_1_jar",
-      "mvn_uri" : "mvn:org.jamon/jamon-runtime/2.4.1",
+      "mvn_uri" : "mvn:org.jamon/jamon-runtime/2.4.1/jar",
       "name" : "jamon-runtime-2.4.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8890,7 +8883,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_janino_3_0_0_jar",
-      "mvn_uri" : "mvn:org.codehaus.janino/janino/3.0.0",
+      "mvn_uri" : "mvn:org.codehaus.janino/janino/3.0.0/jar",
       "name" : "janino-3.0.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8907,7 +8900,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jasper_compiler_5_5_23_jar",
-      "mvn_uri" : "mvn:tomcat/jasper-compiler/5.5.23",
+      "mvn_uri" : "mvn:tomcat/jasper-compiler/5.5.23/jar",
       "name" : "jasper-compiler-5.5.23.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8915,7 +8908,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jasper_runtime_5_5_23_jar",
-      "mvn_uri" : "mvn:tomcat/jasper-runtime/5.5.23",
+      "mvn_uri" : "mvn:tomcat/jasper-runtime/5.5.23/jar",
       "name" : "jasper-runtime-5.5.23.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8923,7 +8916,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_java_xmlbuilder_0_4_jar",
-      "mvn_uri" : "mvn:com.jamesmurty.utils/java-xmlbuilder/0.4",
+      "mvn_uri" : "mvn:com.jamesmurty.utils/java-xmlbuilder/0.4/jar",
       "name" : "java-xmlbuilder-0.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8931,7 +8924,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_javassist_3_18_1_GA_jar",
-      "mvn_uri" : "mvn:org.javassist/javassist/3.18.1-GA",
+      "mvn_uri" : "mvn:org.javassist/javassist/3.18.1-GA/jar",
       "name" : "javassist-3.18.1-GA.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8939,7 +8932,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_javax_annotation_api_1_2_jar",
-      "mvn_uri" : "mvn:javax.annotation/javax.annotation-api/1.2",
+      "mvn_uri" : "mvn:javax.annotation/javax.annotation-api/1.2/jar",
       "name" : "javax.annotation-api-1.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8956,7 +8949,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_javax_inject_1_jar",
-      "mvn_uri" : "mvn:javax.inject/javax.inject/1",
+      "mvn_uri" : "mvn:javax.inject/javax.inject/1/jar",
       "name" : "javax.inject-1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8964,7 +8957,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_javax_inject_2_4_0_b34_jar",
-      "mvn_uri" : "mvn:org.glassfish.hk2.external/javax.inject/2.4.0-b34",
+      "mvn_uri" : "mvn:org.glassfish.hk2.external/javax.inject/2.4.0-b34/jar",
       "name" : "javax.inject-2.4.0-b34.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8972,7 +8965,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_javax_jdo_3_2_0_m3_jar",
-      "mvn_uri" : "mvn:org.datanucleus/javax.jdo/3.2.0-m3",
+      "mvn_uri" : "mvn:org.datanucleus/javax.jdo/3.2.0-m3/jar",
       "name" : "javax.jdo-3.2.0-m3.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8980,7 +8973,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_javax_servlet_3_0_0_v201112011016_jar",
-      "mvn_uri" : "mvn:org.eclipse.jetty.orbit/javax.servlet/3.0.0.v201112011016",
+      "mvn_uri" : "mvn:org.eclipse.jetty.orbit/javax.servlet/3.0.0.v201112011016/jar",
       "name" : "javax.servlet-3.0.0.v201112011016.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8988,7 +8981,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_javax_servlet_api_3_1_0_jar",
-      "mvn_uri" : "mvn:javax.servlet/javax.servlet-api/3.1.0",
+      "mvn_uri" : "mvn:javax.servlet/javax.servlet-api/3.1.0/jar",
       "name" : "javax.servlet-api-3.1.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -8996,7 +8989,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_javax_ws_rs_api_2_0_1_jar",
-      "mvn_uri" : "mvn:javax.ws.rs/javax.ws.rs-api/2.0.1",
+      "mvn_uri" : "mvn:javax.ws.rs/javax.ws.rs-api/2.0.1/jar",
       "name" : "javax.ws.rs-api-2.0.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9004,7 +8997,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_javolution_5_5_1_jar",
-      "mvn_uri" : "mvn:javolution/javolution/5.5.1",
+      "mvn_uri" : "mvn:javolution/javolution/5.5.1/jar",
       "name" : "javolution-5.5.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9012,7 +9005,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jaxb_api_2_2_2_jar",
-      "mvn_uri" : "mvn:javax.xml.bind/jaxb-api/2.2.2",
+      "mvn_uri" : "mvn:javax.xml.bind/jaxb-api/2.2.2/jar",
       "name" : "jaxb-api-2.2.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9020,7 +9013,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jaxb_impl_2_2_3_1_jar",
-      "mvn_uri" : "mvn:com.sun.xml.bind/jaxb-impl/2.2.3-1",
+      "mvn_uri" : "mvn:com.sun.xml.bind/jaxb-impl/2.2.3-1/jar",
       "name" : "jaxb-impl-2.2.3-1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9028,7 +9021,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jcip_annotations_1_0_jar",
-      "mvn_uri" : "mvn:net.jcip/jcip-annotations/1.0",
+      "mvn_uri" : "mvn:net.jcip/jcip-annotations/1.0/jar",
       "name" : "jcip-annotations-1.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9036,7 +9029,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jcl_over_slf4j_1_7_16_jar",
-      "mvn_uri" : "mvn:org.slf4j/jcl-over-slf4j/1.7.16",
+      "mvn_uri" : "mvn:org.slf4j/jcl-over-slf4j/1.7.16/jar",
       "name" : "jcl-over-slf4j-1.7.16.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9044,7 +9037,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jcodings_1_0_8_jar",
-      "mvn_uri" : "mvn:org.jruby.jcodings/jcodings/1.0.8",
+      "mvn_uri" : "mvn:org.jruby.jcodings/jcodings/1.0.8/jar",
       "name" : "jcodings-1.0.8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9052,7 +9045,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jdo_api_3_0_1_jar",
-      "mvn_uri" : "mvn:javax.jdo/jdo-api/3.0.1",
+      "mvn_uri" : "mvn:javax.jdo/jdo-api/3.0.1/jar",
       "name" : "jdo-api-3.0.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9069,7 +9062,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jersey_client_1_9_jar",
-      "mvn_uri" : "mvn:com.sun.jersey/jersey-client/1.9",
+      "mvn_uri" : "mvn:com.sun.jersey/jersey-client/1.9/jar",
       "name" : "jersey-client-1.9.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9077,7 +9070,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jersey_client_2_22_2_jar",
-      "mvn_uri" : "mvn:org.glassfish.jersey.core/jersey-client/2.22.2",
+      "mvn_uri" : "mvn:org.glassfish.jersey.core/jersey-client/2.22.2/jar",
       "name" : "jersey-client-2.22.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9085,7 +9078,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jersey_common_2_22_2_jar",
-      "mvn_uri" : "mvn:org.glassfish.jersey.core/jersey-common/2.22.2",
+      "mvn_uri" : "mvn:org.glassfish.jersey.core/jersey-common/2.22.2/jar",
       "name" : "jersey-common-2.22.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9093,7 +9086,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jersey_container_servlet_2_22_2_jar",
-      "mvn_uri" : "mvn:org.glassfish.jersey.containers/jersey-container-servlet/2.22.2",
+      "mvn_uri" : "mvn:org.glassfish.jersey.containers/jersey-container-servlet/2.22.2/jar",
       "name" : "jersey-container-servlet-2.22.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9101,7 +9094,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jersey_container_servlet_core_2_22_2_jar",
-      "mvn_uri" : "mvn:org.glassfish.jersey.containers/jersey-container-servlet-core/2.22.2",
+      "mvn_uri" : "mvn:org.glassfish.jersey.containers/jersey-container-servlet-core/2.22.2/jar",
       "name" : "jersey-container-servlet-core-2.22.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9109,7 +9102,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jersey_core_1_14_jar",
-      "mvn_uri" : "mvn:com.sun.jersey/jersey-core/1.14",
+      "mvn_uri" : "mvn:com.sun.jersey/jersey-core/1.14/jar",
       "name" : "jersey-core-1.14.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9117,7 +9110,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jersey_guava_2_22_2_jar",
-      "mvn_uri" : "mvn:org.glassfish.jersey.bundles.repackaged/jersey-guava/2.22.2",
+      "mvn_uri" : "mvn:org.glassfish.jersey.bundles.repackaged/jersey-guava/2.22.2/jar",
       "name" : "jersey-guava-2.22.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9125,7 +9118,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jersey_guice_1_9_jar",
-      "mvn_uri" : "mvn:com.sun.jersey.contribs/jersey-guice/1.9",
+      "mvn_uri" : "mvn:com.sun.jersey.contribs/jersey-guice/1.9/jar",
       "name" : "jersey-guice-1.9.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9133,7 +9126,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jersey_json_1_14_jar",
-      "mvn_uri" : "mvn:com.sun.jersey/jersey-json/1.14",
+      "mvn_uri" : "mvn:com.sun.jersey/jersey-json/1.14/jar",
       "name" : "jersey-json-1.14.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9141,7 +9134,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jersey_media_jaxb_2_22_2_jar",
-      "mvn_uri" : "mvn:org.glassfish.jersey.media/jersey-media-jaxb/2.22.2",
+      "mvn_uri" : "mvn:org.glassfish.jersey.media/jersey-media-jaxb/2.22.2/jar",
       "name" : "jersey-media-jaxb-2.22.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9149,7 +9142,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jersey_server_1_14_jar",
-      "mvn_uri" : "mvn:com.sun.jersey/jersey-server/1.14",
+      "mvn_uri" : "mvn:com.sun.jersey/jersey-server/1.14/jar",
       "name" : "jersey-server-1.14.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9157,7 +9150,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jersey_server_2_22_2_jar",
-      "mvn_uri" : "mvn:org.glassfish.jersey.core/jersey-server/2.22.2",
+      "mvn_uri" : "mvn:org.glassfish.jersey.core/jersey-server/2.22.2/jar",
       "name" : "jersey-server-2.22.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9165,7 +9158,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jets3t_0_9_0_jar",
-      "mvn_uri" : "mvn:net.java.dev.jets3t/jets3t/0.9.0",
+      "mvn_uri" : "mvn:net.java.dev.jets3t/jets3t/0.9.0/jar",
       "name" : "jets3t-0.9.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9182,7 +9175,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jettison_1_3_4_jar",
-      "mvn_uri" : "mvn:org.codehaus.jettison/jettison/1.3.4",
+      "mvn_uri" : "mvn:org.codehaus.jettison/jettison/1.3.4/jar",
       "name" : "jettison-1.3.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9190,7 +9183,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jetty_6_1_26_jar",
-      "mvn_uri" : "mvn:org.mortbay.jetty/jetty/6.1.26",
+      "mvn_uri" : "mvn:org.mortbay.jetty/jetty/6.1.26/jar",
       "name" : "jetty-6.1.26.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9198,7 +9191,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jetty_all_7_6_0_v20120127_jar",
-      "mvn_uri" : "mvn:org.eclipse.jetty.aggregate/jetty-all/7.6.0.v20120127",
+      "mvn_uri" : "mvn:org.eclipse.jetty.aggregate/jetty-all/7.6.0.v20120127/jar",
       "name" : "jetty-all-7.6.0.v20120127.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9206,7 +9199,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jetty_util_6_1_26_jar",
-      "mvn_uri" : "mvn:org.mortbay.jetty/jetty-util/6.1.26",
+      "mvn_uri" : "mvn:org.mortbay.jetty/jetty-util/6.1.26/jar",
       "name" : "jetty-util-6.1.26.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9223,7 +9216,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jline_2_12_jar",
-      "mvn_uri" : "mvn:jline/jline/2.12",
+      "mvn_uri" : "mvn:jline/jline/2.12/jar",
       "name" : "jline-2.12.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9231,7 +9224,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jmespath_java_1_11_160_jar",
-      "mvn_uri" : "mvn:com.amazonaws/jmespath-java/1.11.160",
+      "mvn_uri" : "mvn:com.amazonaws/jmespath-java/1.11.160/jar",
       "name" : "jmespath-java-1.11.160.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9239,7 +9232,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jms_1_1_jar",
-      "mvn_uri" : "mvn:javax.jms/jms/1.1",
+      "mvn_uri" : "mvn:javax.jms/jms/1.1/jar",
       "name" : "jms-1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9256,7 +9249,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_joda_time_2_9_4_jar",
-      "mvn_uri" : "mvn:joda-time/joda-time/2.9.4",
+      "mvn_uri" : "mvn:joda-time/joda-time/2.9.4/jar",
       "name" : "joda-time-2.9.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9272,7 +9265,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_joni_2_1_2_jar",
-      "mvn_uri" : "mvn:org.jruby.joni/joni/2.1.2",
+      "mvn_uri" : "mvn:org.jruby.joni/joni/2.1.2/jar",
       "name" : "joni-2.1.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9280,7 +9273,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jpam_1_1_jar",
-      "mvn_uri" : "mvn:net.sf.jpam/jpam/1.1",
+      "mvn_uri" : "mvn:net.sf.jpam/jpam/1.1/jar",
       "name" : "jpam-1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9288,7 +9281,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jsch_0_1_54_jar",
-      "mvn_uri" : "mvn:com.jcraft/jsch/0.1.54",
+      "mvn_uri" : "mvn:com.jcraft/jsch/0.1.54/jar",
       "name" : "jsch-0.1.54.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9296,7 +9289,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_json4s_ast_2_10_3_2_10_jar",
-      "mvn_uri" : "mvn:org.json4s/json4s-ast_2.10/3.2.10",
+      "mvn_uri" : "mvn:org.json4s/json4s-ast_2.10/3.2.10/jar",
       "name" : "json4s-ast_2.10-3.2.10.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9313,7 +9306,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_json4s_ast_2_11_3_2_11_jar",
-      "mvn_uri" : "mvn:org.json4s/json4s-ast_2.11/3.2.11",
+      "mvn_uri" : "mvn:org.json4s/json4s-ast_2.11/3.2.11/jar",
       "name" : "json4s-ast_2.11-3.2.11.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9321,7 +9314,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_json4s_core_2_10_3_2_10_jar",
-      "mvn_uri" : "mvn:org.json4s/json4s-core_2.10/3.2.10",
+      "mvn_uri" : "mvn:org.json4s/json4s-core_2.10/3.2.10/jar",
       "name" : "json4s-core_2.10-3.2.10.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9338,7 +9331,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_json4s_core_2_11_3_2_11_jar",
-      "mvn_uri" : "mvn:org.json4s/json4s-core_2.11/3.2.11",
+      "mvn_uri" : "mvn:org.json4s/json4s-core_2.11/3.2.11/jar",
       "name" : "json4s-core_2.11-3.2.11.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9346,7 +9339,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_json4s_jackson_2_10_3_2_10_jar",
-      "mvn_uri" : "mvn:org.json4s/json4s-jackson_2.10/3.2.10",
+      "mvn_uri" : "mvn:org.json4s/json4s-jackson_2.10/3.2.10/jar",
       "name" : "json4s-jackson_2.10-3.2.10.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9354,7 +9347,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_json4s_jackson_2_11_3_2_11_jar",
-      "mvn_uri" : "mvn:org.json4s/json4s-jackson_2.11/3.2.11",
+      "mvn_uri" : "mvn:org.json4s/json4s-jackson_2.11/3.2.11/jar",
       "name" : "json4s-jackson_2.11-3.2.11.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9371,7 +9364,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_json_20090211_jar",
-      "mvn_uri" : "mvn:org.json/json/20090211",
+      "mvn_uri" : "mvn:org.json/json/20090211/jar",
       "name" : "json-20090211.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9379,7 +9372,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_json_simple_1_1_jar",
-      "mvn_uri" : "mvn:com.googlecode.json-simple/json-simple/1.1",
+      "mvn_uri" : "mvn:com.googlecode.json-simple/json-simple/1.1/jar",
       "name" : "json-simple-1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9387,7 +9380,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_json_smart_1_1_1_jar",
-      "mvn_uri" : "mvn:net.minidev/json-smart/1.1.1",
+      "mvn_uri" : "mvn:net.minidev/json-smart/1.1.1/jar",
       "name" : "json-smart-1.1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9395,7 +9388,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jsp_2_1_6_1_14_jar",
-      "mvn_uri" : "mvn:org.mortbay.jetty/jsp-2.1/6.1.14",
+      "mvn_uri" : "mvn:org.mortbay.jetty/jsp-2.1/6.1.14/jar",
       "name" : "jsp-2.1-6.1.14.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9403,7 +9396,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jsp_api_2_1_6_1_14_jar",
-      "mvn_uri" : "mvn:org.mortbay.jetty/jsp-api-2.1/6.1.14",
+      "mvn_uri" : "mvn:org.mortbay.jetty/jsp-api-2.1/6.1.14/jar",
       "name" : "jsp-api-2.1-6.1.14.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9411,7 +9404,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jsp_api_2_1_jar",
-      "mvn_uri" : "mvn:javax.servlet.jsp/jsp-api/2.1",
+      "mvn_uri" : "mvn:javax.servlet.jsp/jsp-api/2.1/jar",
       "name" : "jsp-api-2.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9419,7 +9412,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jsr305_3_0_0_jar",
-      "mvn_uri" : "mvn:com.google.code.findbugs/jsr305/3.0.0",
+      "mvn_uri" : "mvn:com.google.code.findbugs/jsr305/3.0.0/jar",
       "name" : "jsr305-3.0.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9427,7 +9420,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jta_1_1_jar",
-      "mvn_uri" : "mvn:javax.transaction/jta/1.1",
+      "mvn_uri" : "mvn:javax.transaction/jta/1.1/jar",
       "name" : "jta-1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9435,7 +9428,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jtransforms_2_4_0_jar",
-      "mvn_uri" : "mvn:com.github.rwl/jtransforms/2.4.0",
+      "mvn_uri" : "mvn:com.github.rwl/jtransforms/2.4.0/jar",
       "name" : "jtransforms-2.4.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9443,7 +9436,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_jul_to_slf4j_1_7_16_jar",
-      "mvn_uri" : "mvn:org.slf4j/jul-to-slf4j/1.7.16",
+      "mvn_uri" : "mvn:org.slf4j/jul-to-slf4j/1.7.16/jar",
       "name" : "jul-to-slf4j-1.7.16.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9451,7 +9444,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_junit_4_12_jar",
-      "mvn_uri" : "mvn:junit/junit/4.12",
+      "mvn_uri" : "mvn:junit/junit/4.12/jar",
       "name" : "junit-4.12.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9459,7 +9452,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_kafka_2_11_0_10_0_1_jar",
-      "mvn_uri" : "mvn:org.apache.kafka/kafka_2.11/0.10.0.1",
+      "mvn_uri" : "mvn:org.apache.kafka/kafka_2.11/0.10.0.1/jar",
       "name" : "kafka_2.11-0.10.0.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9499,7 +9492,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_kryo_2_22_jar",
-      "mvn_uri" : "mvn:com.esotericsoftware.kryo/kryo/2.22",
+      "mvn_uri" : "mvn:com.esotericsoftware.kryo/kryo/2.22/jar",
       "name" : "kryo-2.22.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9507,7 +9500,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_kryo_shaded_3_0_3_jar",
-      "mvn_uri" : "mvn:com.esotericsoftware/kryo-shaded/3.0.3",
+      "mvn_uri" : "mvn:com.esotericsoftware/kryo-shaded/3.0.3/jar",
       "name" : "kryo-shaded-3.0.3.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9515,7 +9508,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_leveldbjni_all_1_8_jar",
-      "mvn_uri" : "mvn:org.fusesource.leveldbjni/leveldbjni-all/1.8",
+      "mvn_uri" : "mvn:org.fusesource.leveldbjni/leveldbjni-all/1.8/jar",
       "name" : "leveldbjni-all-1.8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9523,7 +9516,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_libfb303_0_9_3_jar",
-      "mvn_uri" : "mvn:org.apache.thrift/libfb303/0.9.3",
+      "mvn_uri" : "mvn:org.apache.thrift/libfb303/0.9.3/jar",
       "name" : "libfb303-0.9.3.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9531,7 +9524,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_libthrift_0_9_3_jar",
-      "mvn_uri" : "mvn:org.apache.thrift/libthrift/0.9.3",
+      "mvn_uri" : "mvn:org.apache.thrift/libthrift/0.9.3/jar",
       "name" : "libthrift-0.9.3.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9539,7 +9532,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_log4j_1_2_17_jar",
-      "mvn_uri" : "mvn:log4j/log4j/1.2.17",
+      "mvn_uri" : "mvn:log4j/log4j/1.2.17/jar",
       "name" : "log4j-1.2.17.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9547,7 +9540,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_lz4_1_3_0_jar",
-      "mvn_uri" : "mvn:net.jpountz.lz4/lz4/1.3.0",
+      "mvn_uri" : "mvn:net.jpountz.lz4/lz4/1.3.0/jar",
       "name" : "lz4-1.3.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9555,7 +9548,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_mail_1_4_1_jar",
-      "mvn_uri" : "mvn:javax.mail/mail/1.4.1",
+      "mvn_uri" : "mvn:javax.mail/mail/1.4.1/jar",
       "name" : "mail-1.4.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9563,7 +9556,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_mesos_0_21_0_shaded_protobuf_jar",
-      "mvn_uri" : "mvn:org.apache.mesos/mesos/0.21.0/shaded-protobuf",
+      "mvn_uri" : "mvn:org.apache.mesos/mesos/0.21.0/jar/shaded-protobuf",
       "name" : "mesos-0.21.0-shaded-protobuf.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9571,7 +9564,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_metrics_core_2_2_0_jar",
-      "mvn_uri" : "mvn:com.yammer.metrics/metrics-core/2.2.0",
+      "mvn_uri" : "mvn:com.yammer.metrics/metrics-core/2.2.0/jar",
       "name" : "metrics-core-2.2.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9579,7 +9572,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_metrics_core_3_1_2_jar",
-      "mvn_uri" : "mvn:io.dropwizard.metrics/metrics-core/3.1.2",
+      "mvn_uri" : "mvn:io.dropwizard.metrics/metrics-core/3.1.2/jar",
       "name" : "metrics-core-3.1.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9587,7 +9580,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_metrics_graphite_3_1_2_jar",
-      "mvn_uri" : "mvn:io.dropwizard.metrics/metrics-graphite/3.1.2",
+      "mvn_uri" : "mvn:io.dropwizard.metrics/metrics-graphite/3.1.2/jar",
       "name" : "metrics-graphite-3.1.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9595,7 +9588,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_metrics_json_3_1_2_jar",
-      "mvn_uri" : "mvn:io.dropwizard.metrics/metrics-json/3.1.2",
+      "mvn_uri" : "mvn:io.dropwizard.metrics/metrics-json/3.1.2/jar",
       "name" : "metrics-json-3.1.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9603,7 +9596,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_metrics_jvm_3_1_2_jar",
-      "mvn_uri" : "mvn:io.dropwizard.metrics/metrics-jvm/3.1.2",
+      "mvn_uri" : "mvn:io.dropwizard.metrics/metrics-jvm/3.1.2/jar",
       "name" : "metrics-jvm-3.1.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9611,7 +9604,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_minlog_1_3_0_jar",
-      "mvn_uri" : "mvn:com.esotericsoftware/minlog/1.3.0",
+      "mvn_uri" : "mvn:com.esotericsoftware/minlog/1.3.0/jar",
       "name" : "minlog-1.3.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9619,7 +9612,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_netty_3_8_0_Final_jar",
-      "mvn_uri" : "mvn:io.netty/netty/3.8.0.Final",
+      "mvn_uri" : "mvn:io.netty/netty/3.8.0.Final/jar",
       "name" : "netty-3.8.0.Final.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9627,7 +9620,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_netty_all_4_0_42_Final_jar",
-      "mvn_uri" : "mvn:io.netty/netty-all/4.0.42.Final",
+      "mvn_uri" : "mvn:io.netty/netty-all/4.0.42.Final/jar",
       "name" : "netty-all-4.0.42.Final.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9635,7 +9628,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_nimbus_jose_jwt_3_9_jar",
-      "mvn_uri" : "mvn:com.nimbusds/nimbus-jose-jwt/3.9",
+      "mvn_uri" : "mvn:com.nimbusds/nimbus-jose-jwt/3.9/jar",
       "name" : "nimbus-jose-jwt-3.9.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9643,7 +9636,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_objenesis_2_1_jar",
-      "mvn_uri" : "mvn:org.objenesis/objenesis/2.1",
+      "mvn_uri" : "mvn:org.objenesis/objenesis/2.1/jar",
       "name" : "objenesis-2.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9651,7 +9644,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_okhttp_2_4_0_jar",
-      "mvn_uri" : "mvn:com.squareup.okhttp/okhttp/2.4.0",
+      "mvn_uri" : "mvn:com.squareup.okhttp/okhttp/2.4.0/jar",
       "name" : "okhttp-2.4.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9659,7 +9652,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_okio_1_4_0_jar",
-      "mvn_uri" : "mvn:com.squareup.okio/okio/1.4.0",
+      "mvn_uri" : "mvn:com.squareup.okio/okio/1.4.0/jar",
       "name" : "okio-1.4.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9667,7 +9660,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_opencsv_2_3_jar",
-      "mvn_uri" : "mvn:net.sf.opencsv/opencsv/2.3",
+      "mvn_uri" : "mvn:net.sf.opencsv/opencsv/2.3/jar",
       "name" : "opencsv-2.3.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9675,7 +9668,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_oro_2_0_8_jar",
-      "mvn_uri" : "mvn:oro/oro/2.0.8",
+      "mvn_uri" : "mvn:oro/oro/2.0.8/jar",
       "name" : "oro-2.0.8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9683,7 +9676,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_osgi_resource_locator_1_0_1_jar",
-      "mvn_uri" : "mvn:org.glassfish.hk2/osgi-resource-locator/1.0.1",
+      "mvn_uri" : "mvn:org.glassfish.hk2/osgi-resource-locator/1.0.1/jar",
       "name" : "osgi-resource-locator-1.0.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9700,8 +9693,16 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_paranamer_2_7_jar",
-      "mvn_uri" : "mvn:com.thoughtworks.paranamer/paranamer/2.7",
+      "mvn_uri" : "mvn:com.thoughtworks.paranamer/paranamer/2.7/jar",
       "name" : "paranamer-2.7.jar",
+      "tagName" : "libraryNeeded"
+    }, {
+      "childNodes" : [ ],
+      "context" : "plugin:org.talend.hadoop.distribution.hdpx",
+      "excludeDependencies" : "true",
+      "id" : "DYNAMIC_HDP_2_6_0_3_8_parquet_avro_1_4_1",
+      "mvn_uri" : "mvn:com.twitter/parquet-avro/1.4.1",
+      "name" : "parquet-avro-1.4.1.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],
@@ -9716,7 +9717,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_parquet_column_1_8_2_jar",
-      "mvn_uri" : "mvn:org.apache.parquet/parquet-column/1.8.2",
+      "mvn_uri" : "mvn:org.apache.parquet/parquet-column/1.8.2/jar",
       "name" : "parquet-column-1.8.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9724,7 +9725,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_parquet_common_1_8_2_jar",
-      "mvn_uri" : "mvn:org.apache.parquet/parquet-common/1.8.2",
+      "mvn_uri" : "mvn:org.apache.parquet/parquet-common/1.8.2/jar",
       "name" : "parquet-common-1.8.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9732,7 +9733,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_parquet_encoding_1_8_2_jar",
-      "mvn_uri" : "mvn:org.apache.parquet/parquet-encoding/1.8.2",
+      "mvn_uri" : "mvn:org.apache.parquet/parquet-encoding/1.8.2/jar",
       "name" : "parquet-encoding-1.8.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9740,7 +9741,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_parquet_format_2_3_1_jar",
-      "mvn_uri" : "mvn:org.apache.parquet/parquet-format/2.3.1",
+      "mvn_uri" : "mvn:org.apache.parquet/parquet-format/2.3.1/jar",
       "name" : "parquet-format-2.3.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9764,7 +9765,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_parquet_hadoop_bundle_1_8_1_jar",
-      "mvn_uri" : "mvn:org.apache.parquet/parquet-hadoop-bundle/1.8.1",
+      "mvn_uri" : "mvn:org.apache.parquet/parquet-hadoop-bundle/1.8.1/jar",
       "name" : "parquet-hadoop-bundle-1.8.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9772,7 +9773,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_parquet_jackson_1_8_2_jar",
-      "mvn_uri" : "mvn:org.apache.parquet/parquet-jackson/1.8.2",
+      "mvn_uri" : "mvn:org.apache.parquet/parquet-jackson/1.8.2/jar",
       "name" : "parquet-jackson-1.8.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9788,7 +9789,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_parser_core_2_4_jar",
-      "mvn_uri" : "mvn:nl.basjes.parse/parser-core/2.4",
+      "mvn_uri" : "mvn:nl.basjes.parse/parser-core/2.4/jar",
       "name" : "parser-core-2.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9796,7 +9797,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_pig_0_16_0_2_6_0_3_8_h2_jar",
-      "mvn_uri" : "mvn:org.apache.pig/pig/0.16.0.2.6.0.3-8/h2",
+      "mvn_uri" : "mvn:org.apache.pig/pig/0.16.0.2.6.0.3-8/jar/h2",
       "name" : "pig-0.16.0.2.6.0.3-8-h2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9820,7 +9821,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_pmml_model_1_2_15_jar",
-      "mvn_uri" : "mvn:org.jpmml/pmml-model/1.2.15",
+      "mvn_uri" : "mvn:org.jpmml/pmml-model/1.2.15/jar",
       "name" : "pmml-model-1.2.15.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9828,7 +9829,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_pmml_schema_1_2_15_jar",
-      "mvn_uri" : "mvn:org.jpmml/pmml-schema/1.2.15",
+      "mvn_uri" : "mvn:org.jpmml/pmml-schema/1.2.15/jar",
       "name" : "pmml-schema-1.2.15.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9836,7 +9837,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_protobuf_java_2_5_0_spark_jar",
-      "mvn_uri" : "mvn:org.spark-project.protobuf/protobuf-java/2.5.0-spark",
+      "mvn_uri" : "mvn:org.spark-project.protobuf/protobuf-java/2.5.0-spark/jar",
       "name" : "protobuf-java-2.5.0-spark.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9844,7 +9845,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_protobuf_java_2_6_1_jar",
-      "mvn_uri" : "mvn:com.google.protobuf/protobuf-java/2.6.1",
+      "mvn_uri" : "mvn:com.google.protobuf/protobuf-java/2.6.1/jar",
       "name" : "protobuf-java-2.6.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9852,7 +9853,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_py4j_0_10_4_jar",
-      "mvn_uri" : "mvn:net.sf.py4j/py4j/0.10.4",
+      "mvn_uri" : "mvn:net.sf.py4j/py4j/0.10.4/jar",
       "name" : "py4j-0.10.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9860,7 +9861,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_pyrolite_2_0_1_jar",
-      "mvn_uri" : "mvn:org.spark-project/pyrolite/2.0.1",
+      "mvn_uri" : "mvn:org.spark-project/pyrolite/2.0.1/jar",
       "name" : "pyrolite-2.0.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9868,7 +9869,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_pyrolite_4_13_jar",
-      "mvn_uri" : "mvn:net.razorvine/pyrolite/4.13",
+      "mvn_uri" : "mvn:net.razorvine/pyrolite/4.13/jar",
       "name" : "pyrolite-4.13.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9876,7 +9877,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_scala_compiler_2_11_8_jar",
-      "mvn_uri" : "mvn:org.scala-lang/scala-compiler/2.11.8",
+      "mvn_uri" : "mvn:org.scala-lang/scala-compiler/2.11.8/jar",
       "name" : "scala-compiler-2.11.8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9884,7 +9885,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_scala_library_2_11_8_jar",
-      "mvn_uri" : "mvn:org.scala-lang/scala-library/2.11.8",
+      "mvn_uri" : "mvn:org.scala-lang/scala-library/2.11.8/jar",
       "name" : "scala-library-2.11.8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9892,7 +9893,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_scala_parser_combinators_2_11_1_0_4_jar",
-      "mvn_uri" : "mvn:org.scala-lang.modules/scala-parser-combinators_2.11/1.0.4",
+      "mvn_uri" : "mvn:org.scala-lang.modules/scala-parser-combinators_2.11/1.0.4/jar",
       "name" : "scala-parser-combinators_2.11-1.0.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9900,7 +9901,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_scala_reflect_2_11_8_jar",
-      "mvn_uri" : "mvn:org.scala-lang/scala-reflect/2.11.8",
+      "mvn_uri" : "mvn:org.scala-lang/scala-reflect/2.11.8/jar",
       "name" : "scala-reflect-2.11.8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9908,7 +9909,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_scala_xml_2_11_1_0_4_jar",
-      "mvn_uri" : "mvn:org.scala-lang.modules/scala-xml_2.11/1.0.4",
+      "mvn_uri" : "mvn:org.scala-lang.modules/scala-xml_2.11/1.0.4/jar",
       "name" : "scala-xml_2.11-1.0.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9916,7 +9917,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_scalap_2_11_8_jar",
-      "mvn_uri" : "mvn:org.scala-lang/scalap/2.11.8",
+      "mvn_uri" : "mvn:org.scala-lang/scalap/2.11.8/jar",
       "name" : "scalap-2.11.8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9924,7 +9925,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_scalatest_2_11_2_2_6_jar",
-      "mvn_uri" : "mvn:org.scalatest/scalatest_2.11/2.2.6",
+      "mvn_uri" : "mvn:org.scalatest/scalatest_2.11/2.2.6/jar",
       "name" : "scalatest_2.11-2.2.6.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9932,7 +9933,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_servlet_api_2_5_20081211_jar",
-      "mvn_uri" : "mvn:org.mortbay.jetty/servlet-api/2.5-20081211",
+      "mvn_uri" : "mvn:org.mortbay.jetty/servlet-api/2.5-20081211/jar",
       "name" : "servlet-api-2.5-20081211.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9940,7 +9941,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_servlet_api_2_5_6_1_14_jar",
-      "mvn_uri" : "mvn:org.mortbay.jetty/servlet-api-2.5/6.1.14",
+      "mvn_uri" : "mvn:org.mortbay.jetty/servlet-api-2.5/6.1.14/jar",
       "name" : "servlet-api-2.5-6.1.14.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9948,7 +9949,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_servlet_api_2_5_jar",
-      "mvn_uri" : "mvn:javax.servlet/servlet-api/2.5",
+      "mvn_uri" : "mvn:javax.servlet/servlet-api/2.5/jar",
       "name" : "servlet-api-2.5.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9956,7 +9957,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_shapeless_2_11_2_0_0_jar",
-      "mvn_uri" : "mvn:com.chuusai/shapeless_2.11/2.0.0",
+      "mvn_uri" : "mvn:com.chuusai/shapeless_2.11/2.0.0/jar",
       "name" : "shapeless_2.11-2.0.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9973,7 +9974,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_slf4j_api_1_7_21_jar",
-      "mvn_uri" : "mvn:org.slf4j/slf4j-api/1.7.21",
+      "mvn_uri" : "mvn:org.slf4j/slf4j-api/1.7.21/jar",
       "name" : "slf4j-api-1.7.21.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9990,7 +9991,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_slf4j_log4j12_1_7_16_jar",
-      "mvn_uri" : "mvn:org.slf4j/slf4j-log4j12/1.7.16",
+      "mvn_uri" : "mvn:org.slf4j/slf4j-log4j12/1.7.16/jar",
       "name" : "slf4j-log4j12-1.7.16.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -9998,7 +9999,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_slf4j_simple_1_7_7_jar",
-      "mvn_uri" : "mvn:org.slf4j/slf4j-simple/1.7.7",
+      "mvn_uri" : "mvn:org.slf4j/slf4j-simple/1.7.7/jar",
       "name" : "slf4j-simple-1.7.7.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10006,7 +10007,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_snappy_0_2_jar",
-      "mvn_uri" : "mvn:org.iq80.snappy/snappy/0.2",
+      "mvn_uri" : "mvn:org.iq80.snappy/snappy/0.2/jar",
       "name" : "snappy-0.2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10014,7 +10015,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_snappy_java_1_1_2_6_jar",
-      "mvn_uri" : "mvn:org.xerial.snappy/snappy-java/1.1.2.6",
+      "mvn_uri" : "mvn:org.xerial.snappy/snappy-java/1.1.2.6/jar",
       "name" : "snappy-java-1.1.2.6.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10022,7 +10023,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_catalyst_2_11_2_1_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-catalyst_2.11/2.1.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.spark/spark-catalyst_2.11/2.1.0.2.6.0.3-8/jar",
       "name" : "spark-catalyst_2.11-2.1.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10030,7 +10031,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_core_2_10_1_3_1_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-core_2.10/1.3.1",
+      "mvn_uri" : "mvn:org.apache.spark/spark-core_2.10/1.3.1/jar",
       "name" : "spark-core_2.10-1.3.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10038,7 +10039,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_core_2_11_2_1_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-core_2.11/2.1.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.spark/spark-core_2.11/2.1.0.2.6.0.3-8/jar",
       "name" : "spark-core_2.11-2.1.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10046,7 +10047,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_graphx_2_11_2_1_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-graphx_2.11/2.1.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.spark/spark-graphx_2.11/2.1.0.2.6.0.3-8/jar",
       "name" : "spark-graphx_2.11-2.1.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10062,7 +10063,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_launcher_2_11_2_1_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-launcher_2.11/2.1.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.spark/spark-launcher_2.11/2.1.0.2.6.0.3-8/jar",
       "name" : "spark-launcher_2.11-2.1.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10078,7 +10079,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_mllib_local_2_11_2_1_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-mllib-local_2.11/2.1.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.spark/spark-mllib-local_2.11/2.1.0.2.6.0.3-8/jar",
       "name" : "spark-mllib-local_2.11-2.1.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10086,7 +10087,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_network_common_2_10_1_3_1_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-network-common_2.10/1.3.1",
+      "mvn_uri" : "mvn:org.apache.spark/spark-network-common_2.10/1.3.1/jar",
       "name" : "spark-network-common_2.10-1.3.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10094,7 +10095,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_network_common_2_11_2_1_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-network-common_2.11/2.1.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.spark/spark-network-common_2.11/2.1.0.2.6.0.3-8/jar",
       "name" : "spark-network-common_2.11-2.1.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10102,7 +10103,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_network_shuffle_2_10_1_3_1_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-network-shuffle_2.10/1.3.1",
+      "mvn_uri" : "mvn:org.apache.spark/spark-network-shuffle_2.10/1.3.1/jar",
       "name" : "spark-network-shuffle_2.10-1.3.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10110,7 +10111,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_network_shuffle_2_11_2_1_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-network-shuffle_2.11/2.1.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.spark/spark-network-shuffle_2.11/2.1.0.2.6.0.3-8/jar",
       "name" : "spark-network-shuffle_2.11-2.1.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10118,7 +10119,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_sketch_2_11_2_1_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-sketch_2.11/2.1.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.spark/spark-sketch_2.11/2.1.0.2.6.0.3-8/jar",
       "name" : "spark-sketch_2.11-2.1.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10126,7 +10127,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_sql_2_11_2_1_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-sql_2.11/2.1.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.spark/spark-sql_2.11/2.1.0.2.6.0.3-8/jar",
       "name" : "spark-sql_2.11-2.1.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10134,7 +10135,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_streaming_2_11_2_1_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-streaming_2.11/2.1.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.spark/spark-streaming_2.11/2.1.0.2.6.0.3-8/jar",
       "name" : "spark-streaming_2.11-2.1.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10158,7 +10159,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_tags_2_11_2_1_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-tags_2.11/2.1.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.spark/spark-tags_2.11/2.1.0.2.6.0.3-8/jar",
       "name" : "spark-tags_2.11-2.1.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10166,7 +10167,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spark_unsafe_2_11_2_1_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.spark/spark-unsafe_2.11/2.1.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.spark/spark-unsafe_2.11/2.1.0.2.6.0.3-8/jar",
       "name" : "spark-unsafe_2.11-2.1.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10182,7 +10183,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spire_2_11_0_7_4_jar",
-      "mvn_uri" : "mvn:org.spire-math/spire_2.11/0.7.4",
+      "mvn_uri" : "mvn:org.spire-math/spire_2.11/0.7.4/jar",
       "name" : "spire_2.11-0.7.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10190,7 +10191,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spire_macros_2_11_0_7_4_jar",
-      "mvn_uri" : "mvn:org.spire-math/spire-macros_2.11/0.7.4",
+      "mvn_uri" : "mvn:org.spire-math/spire-macros_2.11/0.7.4/jar",
       "name" : "spire-macros_2.11-0.7.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10225,7 +10226,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_spymemcached_2_11_6_jar",
-      "mvn_uri" : "mvn:net.spy/spymemcached/2.11.6",
+      "mvn_uri" : "mvn:net.spy/spymemcached/2.11.6/jar",
       "name" : "spymemcached-2.11.6.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10250,7 +10251,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_stax_api_1_0_1_jar",
-      "mvn_uri" : "mvn:stax/stax-api/1.0.1",
+      "mvn_uri" : "mvn:stax/stax-api/1.0.1/jar",
       "name" : "stax-api-1.0.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10258,7 +10259,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_stax_api_1_0_2_jar",
-      "mvn_uri" : "mvn:javax.xml.stream/stax-api/1.0-2",
+      "mvn_uri" : "mvn:javax.xml.stream/stax-api/1.0-2/jar",
       "name" : "stax-api-1.0-2.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10266,7 +10267,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_stream_2_7_0_jar",
-      "mvn_uri" : "mvn:com.clearspring.analytics/stream/2.7.0",
+      "mvn_uri" : "mvn:com.clearspring.analytics/stream/2.7.0/jar",
       "name" : "stream-2.7.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10274,7 +10275,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_stringtemplate_3_2_1_jar",
-      "mvn_uri" : "mvn:org.antlr/stringtemplate/3.2.1",
+      "mvn_uri" : "mvn:org.antlr/stringtemplate/3.2.1/jar",
       "name" : "stringtemplate-3.2.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10282,7 +10283,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_tachyon_0_5_0_jar",
-      "mvn_uri" : "mvn:org.tachyonproject/tachyon/0.5.0",
+      "mvn_uri" : "mvn:org.tachyonproject/tachyon/0.5.0/jar",
       "name" : "tachyon-0.5.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10290,7 +10291,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_tachyon_client_0_5_0_jar",
-      "mvn_uri" : "mvn:org.tachyonproject/tachyon-client/0.5.0",
+      "mvn_uri" : "mvn:org.tachyonproject/tachyon-client/0.5.0/jar",
       "name" : "tachyon-client-0.5.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10307,7 +10308,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_tez_api_0_7_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.tez/tez-api/0.7.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.tez/tez-api/0.7.0.2.6.0.3-8/jar",
       "name" : "tez-api-0.7.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10315,7 +10316,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_tez_common_0_7_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.tez/tez-common/0.7.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.tez/tez-common/0.7.0.2.6.0.3-8/jar",
       "name" : "tez-common-0.7.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10339,7 +10340,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_tez_runtime_internals_0_7_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.tez/tez-runtime-internals/0.7.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.tez/tez-runtime-internals/0.7.0.2.6.0.3-8/jar",
       "name" : "tez-runtime-internals-0.7.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10347,7 +10348,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_tez_runtime_library_0_7_0_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.tez/tez-runtime-library/0.7.0.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.tez/tez-runtime-library/0.7.0.2.6.0.3-8/jar",
       "name" : "tez-runtime-library-0.7.0.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10355,7 +10356,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_transaction_api_1_1_jar",
-      "mvn_uri" : "mvn:javax.transaction/transaction-api/1.1",
+      "mvn_uri" : "mvn:javax.transaction/transaction-api/1.1/jar",
       "name" : "transaction-api-1.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10363,7 +10364,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_uncommons_maths_1_2_2a_jar",
-      "mvn_uri" : "mvn:org.uncommons.maths/uncommons-maths/1.2.2a",
+      "mvn_uri" : "mvn:org.uncommons.maths/uncommons-maths/1.2.2a/jar",
       "name" : "uncommons-maths-1.2.2a.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10371,7 +10372,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_univocity_parsers_2_2_1_jar",
-      "mvn_uri" : "mvn:com.univocity/univocity-parsers/2.2.1",
+      "mvn_uri" : "mvn:com.univocity/univocity-parsers/2.2.1/jar",
       "name" : "univocity-parsers-2.2.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10379,7 +10380,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_unused_1_0_0_jar",
-      "mvn_uri" : "mvn:org.spark-project.spark/unused/1.0.0",
+      "mvn_uri" : "mvn:org.spark-project.spark/unused/1.0.0/jar",
       "name" : "unused-1.0.0.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10387,7 +10388,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_validation_api_1_1_0_Final_jar",
-      "mvn_uri" : "mvn:javax.validation/validation-api/1.1.0.Final",
+      "mvn_uri" : "mvn:javax.validation/validation-api/1.1.0.Final/jar",
       "name" : "validation-api-1.1.0.Final.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10395,7 +10396,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_velocity_1_7_jar",
-      "mvn_uri" : "mvn:org.apache.velocity/velocity/1.7",
+      "mvn_uri" : "mvn:org.apache.velocity/velocity/1.7/jar",
       "name" : "velocity-1.7.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10403,7 +10404,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_xbean_asm5_shaded_4_4_jar",
-      "mvn_uri" : "mvn:org.apache.xbean/xbean-asm5-shaded/4.4",
+      "mvn_uri" : "mvn:org.apache.xbean/xbean-asm5-shaded/4.4/jar",
       "name" : "xbean-asm5-shaded-4.4.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10411,7 +10412,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_xercesImpl_2_9_1_jar",
-      "mvn_uri" : "mvn:xerces/xercesImpl/2.9.1",
+      "mvn_uri" : "mvn:xerces/xercesImpl/2.9.1/jar",
       "name" : "xercesImpl-2.9.1.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10419,7 +10420,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_xml_apis_1_4_01_jar",
-      "mvn_uri" : "mvn:xml-apis/xml-apis/1.4.01",
+      "mvn_uri" : "mvn:xml-apis/xml-apis/1.4.01/jar",
       "name" : "xml-apis-1.4.01.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10427,7 +10428,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_xmlenc_0_52_jar",
-      "mvn_uri" : "mvn:xmlenc/xmlenc/0.52",
+      "mvn_uri" : "mvn:xmlenc/xmlenc/0.52/jar",
       "name" : "xmlenc-0.52.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10435,7 +10436,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_xz_1_5_jar",
-      "mvn_uri" : "mvn:org.tukaani/xz/1.5",
+      "mvn_uri" : "mvn:org.tukaani/xz/1.5/jar",
       "name" : "xz-1.5.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10443,7 +10444,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_zkclient_0_8_jar",
-      "mvn_uri" : "mvn:com.101tec/zkclient/0.8",
+      "mvn_uri" : "mvn:com.101tec/zkclient/0.8/jar",
       "name" : "zkclient-0.8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10451,7 +10452,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_zookeeper_3_4_6_2_6_0_3_8_jar",
-      "mvn_uri" : "mvn:org.apache.zookeeper/zookeeper/3.4.6.2.6.0.3-8",
+      "mvn_uri" : "mvn:org.apache.zookeeper/zookeeper/3.4.6.2.6.0.3-8/jar",
       "name" : "zookeeper-3.4.6.2.6.0.3-8.jar",
       "tagName" : "libraryNeeded"
     }, {
@@ -10459,7 +10460,7 @@
       "context" : "plugin:org.talend.hadoop.distribution.hdpx",
       "excludeDependencies" : "true",
       "id" : "DYNAMIC_HDP_2_6_0_3_8_zookeeper_3_4_6_2_6_0_3_8_tests_jar",
-      "mvn_uri" : "mvn:org.apache.zookeeper/zookeeper/3.4.6.2.6.0.3-8/tests",
+      "mvn_uri" : "mvn:org.apache.zookeeper/zookeeper/3.4.6.2.6.0.3-8/jar/tests",
       "name" : "zookeeper-3.4.6.2.6.0.3-8-tests.jar",
       "tagName" : "libraryNeeded"
     } ],

--- a/main/plugins/org.talend.hadoop.distribution.hdpx/resources/template/hdpx/hdp2xxTemplate.json
+++ b/main/plugins/org.talend.hadoop.distribution.hdpx/resources/template/hdpx/hdp2xxTemplate.json
@@ -1140,6 +1140,14 @@
       "jarName": "kite-hadoop-compatibility-1.0.0.jar",
       "mvnUri": "mvn:org.kitesdk/kite-hadoop-compatibility/1.0.0",
       "description": ""
+    },
+    {
+      "id": "parquet-avro-1.4.1",
+      "type": "STANDARD",
+      "context": "{properties.context}",
+      "jarName": "parquet-avro-1.4.1.jar",
+      "mvnUri": "mvn:com.twitter/parquet-avro/1.4.1",
+      "description": ""
     }
   ],
   "moduleGroups": [
@@ -1224,7 +1232,8 @@
         "kite-hadoop-compatibility-1.0.0",
         "parquet-avro-1.8.2",
         "parquet-hadoop-bundle",
-        "parquet-hadoop-1.8.2"
+        "parquet-hadoop-1.8.2",
+        "parquet-avro-1.4.1"
       ]
     },
     {


### PR DESCRIPTION
- Added parquet-avro 1.4.1 needed by org.kitesdk:kite-data-core:jar:1.0.0
- Regenerated HDP 2.6 built-in