### PR TITLE
fix(TBD-11309): ClassCastException: org.talend.bigdata.launcher.security.HDInsightCredentials cannot be cast to org.talend.bigdata.http.auth.Credentials

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.hdinsight360/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.hdinsight360/plugin.xml
@@ -130,6 +130,12 @@
                 name="talend-bigdata-launcher-hdinsight-2.0.8.jar"
                 mvn_uri="mvn:org.talend.bigdata.libs/talend-bigdata-launcher-hdinsight/2.0.8">
         </libraryNeeded>
+        <libraryNeeded
+                context="plugin:org.talend.hadoop.distribution.hdinsight360"
+                id="talend-bigdata-launcher-jobserver"
+                name="talend-bigdata-launcher-jobserver-2.0.6.jar"
+                mvn_uri="mvn:org.talend.bigdata.libs/talend-bigdata-launcher-jobserver/2.0.6">
+        </libraryNeeded>
 
         <!-- Groups -->
 
@@ -138,8 +144,8 @@
                 description="Big Data launcher libraries for HDInsight 3.6.0"
                 id="BIGDATA-LAUNCHER-LIB-HD_INSIGHT_3_6_0"
                 name="BIGDATA-LAUNCHER-LIB-HD_INSIGHT_3_6_0"  >
-            <library id="talend-bigdata-launcher"/>
             <library id="talend-bigdata-launcher-hdinsight"/>
+            <library id="talend-bigdata-launcher-jobserver"/>
         </libraryNeededGroup>
 
         <!-- Spark group -->


### PR DESCRIPTION
…edentials cannot be cast to org.talend.bigdata.http.auth.Credentials'

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
