### PR TITLE
fix(TBD-11675):DataProc Spark Hive Job fails with error java.lang.NoSuchMethodException

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.dataproc14/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.dataproc14/plugin.xml
@@ -407,7 +407,7 @@
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="graphframes-0.5.0-spark2.0-s_2.11"
             name="graphframes-0.5.0-spark2.0-s_2.11.jar"
-            mvn_uri="mvn:org.talend.libraries/graphframes-0.5.0-spark2.0-s_2.11/6.0.0">
+            mvn_uri="mvn:graphframes/graphframes/0.5.0-spark2.0-s_2.11">
 		</libraryNeeded>
 		
        <!-- Kafka libraries -->    
@@ -415,14 +415,14 @@
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-streaming-kafka-dataproc14"
             name="spark-streaming-kafka-0-10-assembly_2.11-2.4.7.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-streaming-kafka-0-10-assembly_2.11-2.4.7/6.0.0">
+            mvn_uri="mvn:org.apache.spark/spark-streaming-kafka-0-10-assembly_2.11/2.4.7">
         </libraryNeeded>
         
          <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="kafka-clients-dataproc14"
             name="kafka-clients-0.10.0.1.jar"
-            mvn_uri="mvn:org.talend.libraries/kafka-clients-0.10.0.1/6.3.0">
+            mvn_uri="mvn:org.apache.kafka/kafka-clients/0.10.0.1">
         </libraryNeeded>
             
         <!-- SPARK libraries --> 
@@ -654,7 +654,7 @@
 		    context="plugin:org.talend.hadoop.distribution.dataproc14"
 		    id="libfb303-0.9.3"
 		    name="libfb303-0.9.3.jar"
-		    mvn_uri="mvn:org.talend.libraries/libfb303-0.9.3/6.0.0">
+		    mvn_uri="mvn:org.apache.thrift/libfb303/0.9.3">
         </libraryNeeded>
 
         <libraryNeeded

--- a/main/plugins/org.talend.hadoop.distribution.dataproc14/plugin.xml
+++ b/main/plugins/org.talend.hadoop.distribution.dataproc14/plugin.xml
@@ -414,8 +414,8 @@
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-streaming-kafka-dataproc14"
-            name="spark-streaming-kafka-0-10-assembly_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-streaming-kafka-0-10-assembly_2.11-2.4.3/6.0.0">
+            name="spark-streaming-kafka-0-10-assembly_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.talend.libraries/spark-streaming-kafka-0-10-assembly_2.11-2.4.7/6.0.0">
         </libraryNeeded>
         
          <libraryNeeded
@@ -437,113 +437,113 @@
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-catalyst-dataproc14"
-            name="spark-catalyst_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-catalyst_2.11-2.4.3/6.0.0">
+            name="spark-catalyst_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-catalyst_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-core-dataproc14"
-            name="spark-core_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-core_2.11-2.4.3/6.0.0">
+            name="spark-core_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-core_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-graphx-dataproc14"
-            name="spark-graphx_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-graphx_2.11-2.4.3/6.0.0">
+            name="spark-graphx_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-graphx_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-hive-dataproc14"
-            name="spark-hive_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-hive_2.11-2.4.3/6.0.0">
+            name="spark-hive_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-hive_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-launcher-dataproc14"
-            name="spark-launcher_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-launcher_2.11-2.4.3/6.0.0">
+            name="spark-launcher_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-launcher_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-mllib-dataproc14"
-            name="spark-mllib_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-mllib_2.11-2.4.3/6.0.0">
+            name="spark-mllib_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-mllib_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-mllib-local-dataproc14"
-            name="spark-mllib-local_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-mllib-local_2.11-2.4.3/6.0.0">
+            name="spark-mllib-local_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-mllib-local_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-network-common-dataproc14"
-            name="spark-network-common_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-network-common_2.11-2.4.3/6.0.0">
+            name="spark-network-common_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-network-common_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-network-shuffle-dataproc14"
-            name="spark-network-shuffle_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-network-shuffle_2.11-2.4.3/6.0.0">
+            name="spark-network-shuffle_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-network-shuffle_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-repl-dataproc14"
-            name="spark-repl_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-repl_2.11-2.4.3/6.0.0">
+            name="spark-repl_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-repl_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-sketch-dataproc14"
-            name="spark-sketch_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-sketch_2.11-2.4.3/6.0.0">
+            name="spark-sketch_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-sketch_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-sql-dataproc14"
-            name="spark-sql_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-sql_2.11-2.4.3/6.0.0">
+            name="spark-sql_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-sql_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-streaming-dataproc14"
-            name="spark-streaming_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-streaming_2.11-2.4.3/6.0.0">
+            name="spark-streaming_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-streaming_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-tags-dataproc14"
-            name="spark-tags_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-tags_2.11-2.4.3/6.0.0">
+            name="spark-tags_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-tags_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-unsafe-dataproc14"
-            name="spark-unsafe_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-unsafe_2.11-2.4.3/6.0.0">
+            name="spark-unsafe_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-unsafe_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="spark-yarn-dataproc14"
-            name="spark-yarn_2.11-2.4.3.jar"
-            mvn_uri="mvn:org.talend.libraries/spark-yarn_2.11-2.4.3/6.0.0">
+            name="spark-yarn_2.11-2.4.7.jar"
+            mvn_uri="mvn:org.apache.spark/spark-yarn_2.11/2.4.7">
         </libraryNeeded>
         
         <libraryNeeded context="plugin:org.talend.hadoop.distribution.dataproc14"
@@ -639,14 +639,14 @@
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="hive-exec-dataproc14"
-            name="hive-exec-2.3.4.jar"
-            mvn_uri="mvn:org.talend.libraries/hive-exec-2.3.4/6.0.0">
+            name="hive-exec-2.3.7.jar"
+            mvn_uri="mvn:org.apache.hive/hive-exec/2.3.7">
         </libraryNeeded>
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="hive-metastore-dataproc14"
-            name="hive-metastore-2.3.4.jar"
-            mvn_uri="mvn:org.talend.libraries/hive-metastore-2.3.4/6.0.0">
+            name="hive-metastore-2.3.7.jar"
+            mvn_uri="mvn:org.apache.hive/hive-metastore/2.3.7">
         </libraryNeeded>
 
 		<!-- hive -->
@@ -660,20 +660,20 @@
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="hive-jdbc-dataproc14"
-            name="hive-jdbc-2.3.4.jar"
-            mvn_uri="mvn:org.talend.libraries/hive-jdbc-2.3.4/6.0.0">
+            name="hive-jdbc-2.3.7.jar"
+            mvn_uri="mvn:org.apache.hive/hive-jdbc/2.3.7">
         </libraryNeeded>
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="hive-service-dataproc14"
-            name="hive-service-2.3.4.jar"
-            mvn_uri="mvn:org.talend.libraries/hive-service-2.3.4/6.0.0">
+            name="hive-service-2.3.7.jar"
+            mvn_uri="mvn:org.apache.hive/hive-service/2.3.7">
         </libraryNeeded>
         <libraryNeeded
             context="plugin:org.talend.hadoop.distribution.dataproc14"
             id="hive-service-rpc-dataproc14"
-            name="hive-service-rpc-2.3.4.jar"
-            mvn_uri="mvn:org.talend.libraries/hive-service-rpc-2.3.4/6.0.0">
+            name="hive-service-rpc-2.3.7.jar"
+            mvn_uri="mvn:org.apache.hive/hive-service-rpc/2.3.7">
         </libraryNeeded>
         
         <!-- Groups -->

--- a/main/plugins/org.talend.hadoop.distribution.dataproc14/src/main/java/org/talend/hadoop/distribution/dataproc14/Dataproc14Distribution.java
+++ b/main/plugins/org.talend.hadoop.distribution.dataproc14/src/main/java/org/talend/hadoop/distribution/dataproc14/Dataproc14Distribution.java
@@ -323,4 +323,20 @@ public class Dataproc14Distribution extends AbstractDistribution implements HDFS
     public boolean isHiveWizardCheckEnabled() {
         return true;
     }
+    
+    @Override
+    public boolean doRequireMetastoreVersionOverride() {
+        return true;
+    }
+    
+    @Override
+    public String getHiveMetastoreVersionForSpark() {
+        return "2.3";
+    }
+    
+    @Override
+    public String getHiveMetastoreJars() {
+        return "/usr/lib/hive/lib/*";
+        
+    }
 }

--- a/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/AbstractDistribution.java
+++ b/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/AbstractDistribution.java
@@ -306,6 +306,10 @@ public boolean isQuboleDistribution() {
         return null;
     }
 
+    public String getHiveMetastoreJars() {
+        return "maven";
+    }
+    
     public boolean isHortonworksDistribution() {
         return false;
     }

--- a/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/component/SparkComponent.java
+++ b/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/component/SparkComponent.java
@@ -43,6 +43,12 @@ public interface SparkComponent extends MRComponent {
     public String getHiveMetastoreVersionForSpark();
 
     /**
+     * @return The value to be set in spark.sql.hive.metastore.jars if doRequireMetastoreVersionOverride() returns true 
+     */
+    public String getHiveMetastoreJars();
+
+    
+    /**
      * A distribution can be using Spark 1.3 or Spark 1.4. This method returns the supported Spark versions.
      *
      * @return the collection of supported @link{ESparkVersion} in the distribution.

--- a/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/helper/DistributionsManager.java
+++ b/main/plugins/org.talend.hadoop.distribution/src/main/java/org/talend/hadoop/distribution/helper/DistributionsManager.java
@@ -211,7 +211,7 @@ public final class DistributionsManager implements IDistributionsManager {
     private void addDistribution(BundleContext bc, Map<String, DistributionBean> disctributionsMap, ComponentType type,
             ServiceReference<? extends HadoopComponent> sr) {
         HadoopComponent hc = bc.getService(sr);
-        if (hc.isActivated()) {
+        if (hc != null && hc.isActivated()) {
             final String distribution = hc.getDistribution();
             final String distributionName = hc.getDistributionName();
 


### PR DESCRIPTION
- Updated dependencies to Spark 2.4.7 and Hive 2.3.7 according to https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-1.4
- set metastore jars path to point where driver running on master node can find them



**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
