### PR TITLE
fix(TBD-12671): [BUG] "java.lang.NoSuchMethodError: org.talend.bigdat…

### DIFF
--- a/main/plugins/org.talend.hadoop.distribution.cdp/resources/builtin/cdp/Cloudera_CDP_7_1_1.json
+++ b/main/plugins/org.talend.hadoop.distribution.cdp/resources/builtin/cdp/Cloudera_CDP_7_1_1.json
@@ -8480,7 +8480,7 @@
         "tagName" : "library"
       },  {
         "childNodes" : [ ],
-        "id" : "DYNAMIC_Cloudera_CDP7_1_1_0_565_talend_bigdata_launcher_livy_2_1_1_jar",
+        "id" : "DYNAMIC_Cloudera_CDP7_1_1_0_565_talend_bigdata_launcher_livy_2_1_2_jar",
         "tagName" : "library"
       }, {
         "childNodes" : [ ],
@@ -12813,9 +12813,9 @@
       "childNodes" : [ ],
       "context" : "plugin:org.talend.hadoop.distribution.cdp",
       "excludeDependencies" : "true",
-      "id" : "DYNAMIC_Cloudera_CDP7_1_1_0_565_talend_bigdata_launcher_livy_2_1_1_jar",
-      "mvn_uri" : "mvn:org.talend.bigdata.libs/talend-bigdata-launcher-livy/2.1.1/jar",
-      "name" : "talend-bigdata-launcher-livy-2.1.1.jar",
+      "id" : "DYNAMIC_Cloudera_CDP7_1_1_0_565_talend_bigdata_launcher_livy_2_1_2_jar",
+      "mvn_uri" : "mvn:org.talend.bigdata.libs/talend-bigdata-launcher-livy/2.1.2/jar",
+      "name" : "talend-bigdata-launcher-livy-2.1.2.jar",
       "tagName" : "libraryNeeded"
     }, {
       "childNodes" : [ ],

--- a/main/plugins/org.talend.hadoop.distribution.cdp/resources/template/cdp/cdp7xTemplate.json
+++ b/main/plugins/org.talend.hadoop.distribution.cdp/resources/template/cdp/cdp7xTemplate.json
@@ -725,8 +725,8 @@
             "id": "talend-bigdata-launcher-livy",
             "type": "STANDARD",
             "context": "{properties.context}",
-            "jarName": "talend-bigdata-launcher-livy-2.1.1.jar",
-            "mvnUri": "mvn:org.talend.bigdata.libs/talend-bigdata-launcher-livy/2.1.1/jar",
+            "jarName": "talend-bigdata-launcher-livy-2.1.2.jar",
+            "mvnUri": "mvn:org.talend.bigdata.libs/talend-bigdata-launcher-livy/2.1.2/jar",
             "useStudioRepository": "true"
         },
         {


### PR DESCRIPTION
…a.launcher.utils.Utils.removeLastSlash" is reported when using knox (#2044)

* fix(TBD-12339):Support of Knox for CDP Data Hub Clusters AWS Public Cloud TECH PREVIEW (#1986)

* fix(TBD-12339):Support of Knox for CDP Data Hub Clusters AWS Public Cloud TECH PREVIEW

* fix(TBD-12339):Support of Knox for CDP Data Hub Clusters AWS Public Cloud TECH PREVIEW

* fix(TBD-12339):Support of Knox for CDP Data Hub Clusters AWS Public Cloud TECH PREVIEW

* feat(TBD-12339): add more dependencies to CDP for Knox support

* fix(TBD-12339):Support of Knox for CDP Data Hub Clusters AWS Public Cloud TECH PREVIEW

* fix(TBD-12339):Support of Knox for CDP Data Hub Clusters AWS Public Cloud TECH PREVIEW

* fix(TBD-12339):Support of Knox for CDP Data Hub Clusters AWS Public Cloud TECH PREVIEW

* fix(TBD-12339):Support of Knox for CDP Data Hub Clusters AWS Public Cloud TECH PREVIEW

* fix(TBD-12339):Support of Knox for CDP Data Hub Clusters AWS Public Cloud TECH PREVIEW

* fix(TBD-12339):Support of Knox for CDP Data Hub Clusters AWS Public Cloud TECH PREVIEW

Co-authored-by: Svitlana Ponomarova <sponomarova@talend.com>

* fix(TBD-12339):Upgrade bigdata-launcher-core-2.1.2.jar (#2039)

* fix(TBD-12339):Upgrade bigdata-launcher-core-2.1.2.jar

Co-authored-by: Svitlana Ponomarova <sponomarova@talend.com>

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
