### PR TITLE
fix(TUP-31359)Maven URI is wrong for hadoopcluster-runtime-*.jar and pop

### DIFF
--- a/main/plugins/org.talend.repository.hadoopcluster.configurator/src/org/talend/repository/hadoopcluster/configurator/RetrieveConfigurationProcess.java
+++ b/main/plugins/org.talend.repository.hadoopcluster.configurator/src/org/talend/repository/hadoopcluster/configurator/RetrieveConfigurationProcess.java
@@ -145,7 +145,6 @@ public class RetrieveConfigurationProcess extends org.talend.designer.core.ui.ed
         NodeContainer javaContainer = new NodeContainer(javaNode);
         this.addNodeContainer(javaContainer);
         //
-        initTLibraryLoadNode(inputNode);
     }
 
     private Node getInputNode() {


### PR DESCRIPTION
up missing asm-3.1.jar when check BD connection

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**BREAKING CHANGE**

If this PR contains a breaking change, please describe the impact and migration
path for existing applications.
If not please remove this section.

**Other information**:
